### PR TITLE
fix(heka-identity-service): update docker base image to node 22 to fix ESM require errors

### DIFF
--- a/heka-identity-service/Dockerfile
+++ b/heka-identity-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:22-bullseye-slim
 
 ARG EXPRESS_PORT
 


### PR DESCRIPTION
**Description**:

Resolves a silent container crash during backend startup caused by `ERR_REQUIRE_ESM`. The `ts-node` environment on `node:18` fails to resolve the modern ES Modules exported by the updated `@credo-ts/openid4vc` library required for schema handling. 

* Upgrade `heka-identity-service/Dockerfile` base image from `node:18-bullseye-slim` to `node:22-bullseye-slim`
* Enable seamless modern ESM/CommonJS interop during `yarn start` and database migrations

**Related issue(s)**:

Fixes # 

**Notes for reviewer**:
Node 22 allows the local development setup via `docker compose up -d` to build and mount properly without failing the internal schema/credential module resolution. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
