### PR TITLE
docs(identity-service): correct default JWT Audience configuration

### DIFF
--- a/heka-identity-service/docs/setup.md
+++ b/heka-identity-service/docs/setup.md
@@ -34,7 +34,7 @@ Identity Service endpoints are protected with JWT Authentication and require int
 You can modify JWT verification options by setting the following environment variables:
 - `JWT_SECRET` - secret used to sign and verify tokens, defaults to `test`
 - `JWT_VERIFY_OPTIONS_ISSUER` - required value of `iss` claim, defaults to `Heka`
-- `JWT_VERIFY_OPTIONS_AUDIENCE` - required value of `aud` claim, defaults to `Heka Identity Platform`
+- `JWT_VERIFY_OPTIONS_AUDIENCE` - required value of `aud` claim, defaults to `Heka Identity Service`
 
 While integration with external auth providers is supported, it's recommended to use [Heka Auth Service](https://github.com/hiero-ledger/heka-identity-platform/tree/main/heka-auth-service) for basic deployments.
 


### PR DESCRIPTION
**Description**:

Corrects a documentation typo that causes confusion around the default `aud` claims necessary for validating JWTs. 

* Update the default value of `JWT_VERIFY_OPTIONS_AUDIENCE` in `setup.md` from `Heka Identity Platform` to `Heka Identity Service` 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
The actual default expectation in `src/config/jwt.ts` is `Heka Identity Service`. By correcting this in the documentation, developers spinning up the generic Auth Service alongside the Identity Service will not face initial `401 Unauthorized` errors.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
