### PR TITLE
fix(openid4vc): correct DELETE verification session route parameter syntax

### DIFF
--- a/heka-identity-service/src/openid4vc/verification-sessions/verification-session.controller.ts
+++ b/heka-identity-service/src/openid4vc/verification-sessions/verification-session.controller.ts
@@ -137,7 +137,7 @@ export class OpenId4VcVerificationSessionController {
   @ApiUnprocessableEntityResponse({ description: 'Unprocessable Entity' })
   @HttpCode(HttpStatus.NO_CONTENT)
   @Roles(Role.Admin, Role.OrgAdmin, Role.OrgManager, Role.Verifier)
-  @Delete('/{verificationSessionId}')
+  @Delete(':verificationSessionId')
   public async deleteVerificationSession(
     @ReqTenantAgent() tenantAgent: TenantAgent,
     @Param('verificationSessionId') verificationSessionId: string,


### PR DESCRIPTION
**Description:**  
The `DELETE` route for verification sessions was using OpenAPI-style path syntax (`/{verificationSessionId}`), which NestJS doesn’t interpret as a dynamic parameter. Because of this, the route was treated literally and all valid delete requests were returning `404 Not Found`. This meant stale or completed sessions were not getting cleaned up properly.

* Replaced `@Delete('/{verificationSessionId}')` with `@Delete(':verificationSessionId')` to match NestJS routing syntax  
* Verified that the `verificationSessionId` is now correctly extracted from the request URL  

**Related issue(s):**  
No existing issue — found this while reviewing the verification session flow.

**Notes for reviewer:**  
This is a very small fix but it was breaking the entire delete flow.  
* Earlier, the route never matched due to incorrect syntax  
* Now, it correctly picks up the session ID and allows proper cleanup of expired/finished sessions  

**Checklist**

- [ ] Documented (Code comments/OpenAPI specs updated if necessary)  
- [x] Tested (`yarn check-types:src` and `yarn lint-check src/openid4vc/verification-sessions/verification-session.controller.ts` pass successfully)