### PR TITLE
docs(auth): fix README code fence in local Postgres setup

### DIFF
--- a/heka-auth-service/README.md
+++ b/heka-auth-service/README.md
@@ -9,8 +9,7 @@ Authentication service for [Heka Identity Service](https://github.com/hiero-ledg
 #### Locally
 
 1. Run local Postgres database with the following command:
-   ```
-   bash
+   ```bash
    $ docker run --name heka-auth-service-postgres -e POSTGRES_DB=heka-auth-service -e POSTGRES_USER=heka -e POSTGRES_PASSWORD=heka1 -p 5433:5432 -d postgres
    ```
 2. Install dependencies:


### PR DESCRIPTION
**Description**:
Fix malformed Markdown in `heka-auth-service/README.md` local setup instructions so the Postgres command is clear and copy/paste-safe.

* Use a proper `bash` fenced code block for the local Postgres command
* Remove the stray standalone `bash` line inside the snippet

**Related issue(s)**:

Fixes #19

**Notes for reviewer**:
Doc-only change. No runtime or behavior impact.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)