### PR TITLE
ci: update workflows to use self-hosted runners

### DIFF
--- a/.github/workflows/heka-auth-service-publish.yml
+++ b/.github/workflows/heka-auth-service-publish.yml
@@ -30,7 +30,7 @@ jobs:
     defaults:
       run:
         working-directory: ./heka-auth-service
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/heka-auth-service-verify.yml
+++ b/.github/workflows/heka-auth-service-verify.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./heka-auth-service
     name: Build and check
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
 
     services:
       postgres:

--- a/.github/workflows/heka-identity-service-publish.yml
+++ b/.github/workflows/heka-identity-service-publish.yml
@@ -30,7 +30,7 @@ jobs:
     defaults:
       run:
         working-directory: ./heka-identity-service
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/heka-identity-service-verify.yml
+++ b/.github/workflows/heka-identity-service-verify.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./heka-identity-service
     name: Build and check
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
 
     services:
       postgres:

--- a/.github/workflows/heka-identity-service-web-ui-verify.yml
+++ b/.github/workflows/heka-identity-service-web-ui-verify.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./heka-identity-service-web-ui
     name: Build and check
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/heka-wallet-build-android.yml
+++ b/.github/workflows/heka-wallet-build-android.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: ./heka-wallet
     name: Build Android APK & AAB
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
     outputs:
       version: ${{ steps.version.outputs.version }}
 

--- a/.github/workflows/heka-wallet-verify.yml
+++ b/.github/workflows/heka-wallet-verify.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: ./heka-wallet
     name: Build and check
-    runs-on: ubuntu-latest
+    runs-on: hl-heka-lin-md
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
**Description**:

Migrate all GitHub Actions workflows to use Hiero self-hosted runners to align with organization-wide security requirements and existing repository patterns.

* Replace `runs-on: ubuntu-latest` with `hl-heka-lin-md` across all workflows
* Ensure consistency with other Hiero repositories (e.g., DID SDK JS, Identity Collaboration Hub)
* Maintain existing workflow behavior while updating execution environment

---

**Related issue(s)**:

Fixes #6

---

**Notes for reviewer**:

* This change follows the same migration pattern already applied in other Hiero repositories
* No functional changes to workflow logic; only runner environment updated
* All jobs should behave identically, but now execute on self-hosted runners as required by org policy

---

**Checklist**

* [ ] Documented (Code comments, README, etc.)
* [x] Tested (workflows should trigger on PR/push as before)
