### PR TITLE
fix(wallet): delay hiding splash screen on iOS first launch until keychain reset completes

### DIFF
--- a/heka-wallet/app/App.tsx
+++ b/heka-wallet/app/App.tsx
@@ -40,17 +40,19 @@ const App = () => {
     initStoredLanguage()
   }, [])
 
-  useEffect(() => {
-    // Hide the native splash / loading screen so that our
-    // RN version can be displayed.
-    SplashScreen.hide()
-  }, [])
-
   // This is required for consistent Keychain behavior on iOS and Android in cases where user re-installs the app
   // We want to clear Keychain data after deleting the app, but it's not possible on iOS
   // So we need to manually reset keychain data on first app launch on iOS
   // See https://github.com/oblador/react-native-keychain/issues/135
   const { inProgress: keychainResetInProgress } = useIOSKeychainResetOnFirstLaunch()
+
+  useEffect(() => {
+    // Hide the native splash / loading screen so that our
+    // RN version can be displayed.
+    if (!keychainResetInProgress) {
+      SplashScreen.hide()
+    }
+  }, [keychainResetInProgress])
 
   // TODO: Find a way to show splash instead of a blank screen
   // Do not render anything before keychain reset is completed


### PR DESCRIPTION
Delay hiding splash screen on iOS until keychain reset completes to prevent blank screen on first launch.

* Fix SplashScreen.hide() called unconditionally on app mount
* Add guard to only hide splash screen when keychainResetInProgress is false
* Resolves the TODO comment left by developers at App.tsx line 55


NOTE :
On iOS first launch, the app resets the device keychain before proceeding. 
Previously, SplashScreen.hide() was called immediately, causing a blank 
white/black screen during the reset. This fix ensures the splash screen 
persists until initialization is complete.
