### PR TITLE
fix(auth): correct demo token expiry

### DIFF
--- a/heka-auth-service/src/core/config/configs/jwt.config.ts
+++ b/heka-auth-service/src/core/config/configs/jwt.config.ts
@@ -15,7 +15,7 @@ export const jwtConfigDefaults = {
   secret: 'test',
   accessExpiry: 60 * 60, // 1h
   refreshExpiry: 86400, // 24h
-  demoUserTokenExpiry: 1000 * 24 * 60 * 60 * 30 * 12, // ~1 years validity for Demo User
+  demoUserTokenExpiry: 60 * 60 * 24 * 365, // ~1 year validity for Demo User
 }
 
 export class JwtConfig {

--- a/heka-auth-service/src/oauth/oauth.service.ts
+++ b/heka-auth-service/src/oauth/oauth.service.ts
@@ -165,7 +165,7 @@ export class OAuthService {
 
     return {
       token,
-      expiresIn: this.configService.jwtConfig.accessExpiry,
+      expiresIn: accessTokenExpiresIn,
     }
   }
 


### PR DESCRIPTION
**Description**:
Fix demo-user access token expiry handling in `heka-auth-service` so default expiry is truly ~1 year (in seconds) and API response `expiresIn` matches the effective value used to sign the token.

* Change `demoUserTokenExpiry` default from a millisecond-like expression to `60 * 60 * 24 * 365` seconds
* Return `accessTokenExpiresIn` from OAuth token generation instead of always returning standard `accessExpiry`

**Related issue(s)**:

Fixes #28

**Notes for reviewer**:
Validated numerically before and after fix.

Before:
- `demoUserTokenExpiry = 31104000000`
- `31104000000 / (60*60*24*365) = 986.30y`

After:
- `demoUserTokenExpiry = 31536000`
- `31536000 / (60*60*24*365) = 1.00y`

Branch/commit:
- Branch: `fix/auth-demo-expiry-seconds`
- Commit: `658a844` (`fix(auth): correct demo token expiry`)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)