### PR TITLE
fix(wallet): enable OpenID4VC credential status verification by default

### DIFF
--- a/heka-wallet/README.md
+++ b/heka-wallet/README.md
@@ -36,6 +36,17 @@ yarn lint
 yarn test
 ```
 
+### OpenID4VCI credential status verification
+
+When receiving credentials via OpenID4VCI, the wallet calls Credo’s `requestCredentials` with **`verifyCredentialStatus: true` by default**, so revoked credentials or failed status-list checks are rejected instead of being stored.
+
+- **Production and release builds:** status verification is always enabled; a revoked or invalid-status credential will surface an error and will not be saved.
+- **Development only:** you can disable verification for local issuers without status infrastructure by setting in your app env (e.g. `.env` used by `react-native-config`):
+
+  `DISABLE_OPENID4VC_CREDENTIAL_STATUS_VERIFY=true`
+
+  This escape hatch is ignored outside `__DEV__`. Prefer fixing the issuer’s status endpoints rather than relying on this flag.
+
 ## Run the app
 
 Note that it's strongly recommended to use a physical device instead of emulator.

--- a/heka-wallet/app/__tests__/credentials/openId4VcCredentialStatus.spec.ts
+++ b/heka-wallet/app/__tests__/credentials/openId4VcCredentialStatus.spec.ts
@@ -1,0 +1,34 @@
+import {
+  isOpenId4VcCredentialStatusFailure,
+  shouldVerifyOpenId4VcCredentialStatus,
+} from '../../src/credentials/openId4VcCredentialStatus'
+
+describe('openId4VcCredentialStatus', () => {
+  describe('isOpenId4VcCredentialStatusFailure', () => {
+    it('returns true when message indicates revocation', () => {
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Credential has been revoked'))).toBe(true)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Revocation registry error'))).toBe(true)
+    })
+
+    it('returns true for status list / verification failures', () => {
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Status list fetch failed'))).toBe(true)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Credential status verification failed'))).toBe(true)
+    })
+
+    it('returns false for unrelated errors', () => {
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Network timeout'))).toBe(false)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Invalid proof of possession'))).toBe(false)
+    })
+
+    it('returns false for non-errors', () => {
+      expect(isOpenId4VcCredentialStatusFailure(null)).toBe(false)
+      expect(isOpenId4VcCredentialStatusFailure(undefined)).toBe(false)
+    })
+  })
+
+  describe('shouldVerifyOpenId4VcCredentialStatus', () => {
+    it('returns true by default in test environment (no dev-only disable)', () => {
+      expect(shouldVerifyOpenId4VcCredentialStatus()).toBe(true)
+    })
+  })
+})

--- a/heka-wallet/app/__tests__/credentials/openId4VcCredentialStatus.spec.ts
+++ b/heka-wallet/app/__tests__/credentials/openId4VcCredentialStatus.spec.ts
@@ -1,23 +1,69 @@
+import { CredoError } from '@credo-ts/core'
 import {
   isOpenId4VcCredentialStatusFailure,
   shouldVerifyOpenId4VcCredentialStatus,
 } from '../../src/credentials/openId4VcCredentialStatus'
 
+function sdJwtException(message: string): Error {
+  const err = new Error(message)
+  err.name = 'SDJWTException'
+  return err
+}
+
 describe('openId4VcCredentialStatus', () => {
   describe('isOpenId4VcCredentialStatusFailure', () => {
-    it('returns true when message indicates revocation', () => {
-      expect(isOpenId4VcCredentialStatusFailure(new Error('Credential has been revoked'))).toBe(true)
-      expect(isOpenId4VcCredentialStatusFailure(new Error('Revocation registry error'))).toBe(true)
+    it('returns true for SD-JWT status list failures from @sd-jwt/utils', () => {
+      expect(isOpenId4VcCredentialStatusFailure(sdJwtException('Status is not valid'))).toBe(true)
+      expect(isOpenId4VcCredentialStatusFailure(sdJwtException('Status list is expired'))).toBe(true)
     })
 
-    it('returns true for status list / verification failures', () => {
-      expect(isOpenId4VcCredentialStatusFailure(new Error('Status list fetch failed'))).toBe(true)
-      expect(isOpenId4VcCredentialStatusFailure(new Error('Credential status verification failed'))).toBe(true)
+    it('returns true when status list HTTP fetch fails (sd-jwt default fetcher)', () => {
+      expect(
+        isOpenId4VcCredentialStatusFailure(new Error('Error fetching status list: 503 upstream'))
+      ).toBe(true)
     })
 
-    it('returns false for unrelated errors', () => {
+    it('returns true for Credo W3C JWT / JSON-LD credential status messages', () => {
+      expect(
+        isOpenId4VcCredentialStatusFailure(new CredoError('Verifying credential status is not supported for JWT VCs'))
+      ).toBe(true)
+      expect(
+        isOpenId4VcCredentialStatusFailure(
+          new CredoError('Verifying credential status for JSON-LD credentials is currently not supported')
+        )
+      ).toBe(true)
+    })
+
+    it('returns true for Credo status list HTTP errors (wallet fetcher)', () => {
+      expect(
+        isOpenId4VcCredentialStatusFailure(
+          new CredoError(
+            'Received invalid response with status 502 when fetching status list from https://issuer.example/status. body'
+          )
+        )
+      ).toBe(true)
+    })
+
+    it('returns true for wrapped Credo OpenID4VCI validation errors', () => {
+      expect(
+        isOpenId4VcCredentialStatusFailure(
+          new CredoError('Failed to validate credential, error = Verifying credential status is not supported for JWT VCs')
+        )
+      ).toBe(true)
+    })
+
+    it('returns true when a matching failure is in the error cause chain', () => {
+      const root = new CredoError('outer', { cause: sdJwtException('Status is not valid') })
+      expect(isOpenId4VcCredentialStatusFailure(root)).toBe(true)
+    })
+
+    it('returns false for unrelated or ambiguous natural-language errors', () => {
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Credential has been revoked'))).toBe(false)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Revocation registry error'))).toBe(false)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Certificate verification failed'))).toBe(false)
       expect(isOpenId4VcCredentialStatusFailure(new Error('Network timeout'))).toBe(false)
       expect(isOpenId4VcCredentialStatusFailure(new Error('Invalid proof of possession'))).toBe(false)
+      expect(isOpenId4VcCredentialStatusFailure(new Error('Status is not valid'))).toBe(false)
     })
 
     it('returns false for non-errors', () => {

--- a/heka-wallet/app/__tests__/credentials/useOpenIdHandlers.spec.ts
+++ b/heka-wallet/app/__tests__/credentials/useOpenIdHandlers.spec.ts
@@ -4,6 +4,7 @@ import { getHostNameFromUrl } from '@heka-wallet/shared'
 import { renderHook } from '@testing-library/react-native'
 
 import { mockFunction } from '../../../jest-helpers/helpers'
+import * as openId4VcCredentialStatus from '../../src/credentials/openId4VcCredentialStatus'
 import { useOpenIdHandlers } from '../../src/credentials/useOpenIdHandlers'
 
 import { hekaIdentityServiceSdJwtVc } from './fixtures'
@@ -187,6 +188,14 @@ describe('useOpenIdHandlers', () => {
   })
 
   describe('receiveCredentialFromOpenId4VciOffer', () => {
+    beforeEach(() => {
+      jest.spyOn(openId4VcCredentialStatus, 'shouldVerifyOpenId4VcCredentialStatus').mockReturnValue(true)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
     it('should receive specified credential from resolved offer', async () => {
       mockFunction(mockAgent.modules.openId4VcHolder.requestCredentials).mockResolvedValueOnce(
         fixture.requestCredentialsResponse
@@ -208,7 +217,7 @@ describe('useOpenIdHandlers', () => {
         ...fixture.tokenResponse,
         clientId: undefined,
         credentialsToRequest: [credentialIdToRequest],
-        verifyCredentialStatus: false,
+        verifyCredentialStatus: true,
         allowedProofOfPossessionSignatureAlgorithms: [JwaSignatureAlgorithm.EdDSA, JwaSignatureAlgorithm.ES256],
         credentialBindingResolver: expect.any(Function),
       })
@@ -234,11 +243,49 @@ describe('useOpenIdHandlers', () => {
         ...fixture.tokenResponse,
         clientId: undefined,
         credentialsToRequest: [mixedFormatResolvedCredentialOffer.offeredCredentials[1].id],
-        verifyCredentialStatus: false,
+        verifyCredentialStatus: true,
         allowedProofOfPossessionSignatureAlgorithms: [JwaSignatureAlgorithm.EdDSA, JwaSignatureAlgorithm.ES256],
         credentialBindingResolver: expect.any(Function),
       })
       expect(mockAgent.modules.openId4VcHolder.requestCredentials).toHaveBeenCalledTimes(1)
+    })
+
+    it('should pass verifyCredentialStatus false when dev escape hatch disables verification', async () => {
+      jest.spyOn(openId4VcCredentialStatus, 'shouldVerifyOpenId4VcCredentialStatus').mockReturnValue(false)
+      mockFunction(mockAgent.modules.openId4VcHolder.requestCredentials).mockResolvedValueOnce(
+        fixture.requestCredentialsResponse
+      )
+
+      const { receiveCredentialFromOpenId4VciOffer } = renderOpenIdHandlersHookValue()
+      await receiveCredentialFromOpenId4VciOffer({
+        resolvedCredentialOffer: fixture.resolvedCredentialOfferPreAuth,
+        accessToken: fixture.tokenResponse,
+      })
+
+      expect(mockAgent.modules.openId4VcHolder.requestCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          verifyCredentialStatus: false,
+        })
+      )
+    })
+
+    it('should propagate when issuer rejects revoked credential after status verification', async () => {
+      mockFunction(mockAgent.modules.openId4VcHolder.requestCredentials).mockRejectedValueOnce(
+        new Error('Credential has been revoked')
+      )
+
+      const { receiveCredentialFromOpenId4VciOffer } = renderOpenIdHandlersHookValue()
+
+      await expect(
+        receiveCredentialFromOpenId4VciOffer({
+          resolvedCredentialOffer: fixture.resolvedCredentialOfferPreAuth,
+          accessToken: fixture.tokenResponse,
+        })
+      ).rejects.toThrow(/revoked/i)
+
+      expect(mockAgent.modules.openId4VcHolder.requestCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({ verifyCredentialStatus: true })
+      )
     })
 
     it('should throw if explicitly requested credential uses an unsupported format', async () => {

--- a/heka-wallet/app/src/credentials/index.ts
+++ b/heka-wallet/app/src/credentials/index.ts
@@ -1,6 +1,7 @@
 export * from './types'
 export * from './mappers'
 export * from './metadata'
+export * from './openId4VcCredentialStatus'
 export * from './useCredentials'
 export * from './useOpenIdHandlers'
 export * from './useCredentialRecordHelpers'

--- a/heka-wallet/app/src/credentials/openId4VcCredentialStatus.ts
+++ b/heka-wallet/app/src/credentials/openId4VcCredentialStatus.ts
@@ -1,4 +1,75 @@
+import { CredoError } from '@credo-ts/core'
 import { Config } from 'react-native-config'
+
+/**
+ * Exact messages from @credo-ts/core@0.5.19 W3C VC verification when credential status checks apply.
+ * If Credo is upgraded, re-sync with:
+ * - modules/vc/jwt-vc/W3cJwtCredentialService
+ * - modules/vc/data-integrity/W3cJsonLdCredentialService
+ */
+const CREDO_JWT_VC_CREDENTIAL_STATUS_UNSUPPORTED =
+  'Verifying credential status is not supported for JWT VCs'
+const CREDO_JSONLD_CREDENTIAL_STATUS_UNSUPPORTED =
+  'Verifying credential status for JSON-LD credentials is currently not supported'
+
+/** Prefix of CredoError when W3C credential verification fails (OpenId4VciHolderService). */
+const CREDO_W3C_VALIDATE_PREFIX = 'Failed to validate credential, error = '
+
+/**
+ * @sd-jwt/sd-jwt-vc status handling (via @sd-jwt/utils).
+ * "Status is not valid" means a non-zero status list entry (e.g. suspended/revoked).
+ */
+const SDJWT_STATUS_FAILURE_MESSAGES = new Set(['Status is not valid', 'Status list is expired'])
+
+/** Matches `SDJWTException` from `@sd-jwt/utils` without taking a direct package dependency. */
+function isSdJwtException(error: unknown): error is Error {
+  return error instanceof Error && error.name === 'SDJWTException'
+}
+
+/** Credo SdJwtVcService when the status list HTTP response is not OK. */
+const CREDO_STATUS_LIST_HTTP_ERROR = /^Received invalid response with status \d+ when fetching status list from /
+
+/** Default @sd-jwt/sd-jwt-vc fetcher when the status list HTTP response is not OK. */
+const SDJWT_STATUS_LIST_HTTP_ERROR = /^Error fetching status list: /
+
+function* eachErrorInChain(error: unknown): Generator<unknown> {
+  let current: unknown = error
+  const seen = new Set<unknown>()
+
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current)
+    yield current
+
+    if (current instanceof Error && 'cause' in current) {
+      const { cause } = current as Error & { cause?: unknown }
+      if (cause === undefined || cause === null) {
+        break
+      }
+      current = cause
+    } else {
+      break
+    }
+  }
+}
+
+function isCredoStatusListHttpMessage(message: string): boolean {
+  return CREDO_STATUS_LIST_HTTP_ERROR.test(message)
+}
+
+function isSdJwtStatusListHttpMessage(message: string): boolean {
+  return SDJWT_STATUS_LIST_HTTP_ERROR.test(message)
+}
+
+function isCredoWrappedW3cCredentialStatusMessage(message: string): boolean {
+  if (!message.startsWith(CREDO_W3C_VALIDATE_PREFIX)) {
+    return false
+  }
+  const inner = message.slice(CREDO_W3C_VALIDATE_PREFIX.length)
+  return (
+    inner === CREDO_JWT_VC_CREDENTIAL_STATUS_UNSUPPORTED ||
+    inner === CREDO_JSONLD_CREDENTIAL_STATUS_UNSUPPORTED
+  )
+}
 
 /**
  * Whether OpenID4VCI `requestCredentials` should verify credential status (revocation, status lists, etc.).
@@ -17,35 +88,38 @@ export function shouldVerifyOpenId4VcCredentialStatus(): boolean {
 }
 
 /**
- * Best-effort detection of Credo / issuer errors related to credential status or revocation,
- * for user-facing messaging when status verification is enabled.
+ * Detects credential-status or status-list failures using error types and stable messages from
+ * `@credo-ts/core` / `@sd-jwt/*` — not ad-hoc substring matching on arbitrary issuer text.
  */
 export function isOpenId4VcCredentialStatusFailure(error: unknown): boolean {
   if (error === null || error === undefined) {
     return false
   }
 
-  const message =
-    typeof error === 'string'
-      ? error
-      : error instanceof Error
-        ? `${error.message} ${'cause' in error && error.cause instanceof Error ? error.cause.message : ''}`
-        : String(error)
+  for (const err of eachErrorInChain(error)) {
+    if (isSdJwtException(err) && SDJWT_STATUS_FAILURE_MESSAGES.has(err.message)) {
+      return true
+    }
 
-  const normalized = message.toLowerCase()
-  const patterns = [
-    'revok',
-    'revocation',
-    'credential status',
-    'status list',
-    'statuslist',
-    'invalid status',
-    'credential is not active',
-    'not active',
-    'has been revoked',
-    'verification failed',
-    'status verification',
-  ]
+    if (err instanceof CredoError) {
+      if (err.message === CREDO_JWT_VC_CREDENTIAL_STATUS_UNSUPPORTED) {
+        return true
+      }
+      if (err.message === CREDO_JSONLD_CREDENTIAL_STATUS_UNSUPPORTED) {
+        return true
+      }
+      if (isCredoStatusListHttpMessage(err.message)) {
+        return true
+      }
+      if (isCredoWrappedW3cCredentialStatusMessage(err.message)) {
+        return true
+      }
+    }
 
-  return patterns.some((p) => normalized.includes(p))
+    if (err instanceof Error && isSdJwtStatusListHttpMessage(err.message)) {
+      return true
+    }
+  }
+
+  return false
 }

--- a/heka-wallet/app/src/credentials/openId4VcCredentialStatus.ts
+++ b/heka-wallet/app/src/credentials/openId4VcCredentialStatus.ts
@@ -1,0 +1,51 @@
+import { Config } from 'react-native-config'
+
+/**
+ * Whether OpenID4VCI `requestCredentials` should verify credential status (revocation, status lists, etc.).
+ * Default is true for production trust. In __DEV__ only, set env `DISABLE_OPENID4VC_CREDENTIAL_STATUS_VERIFY=true`
+ * to opt out for local issuer labs that lack status infrastructure.
+ */
+export function shouldVerifyOpenId4VcCredentialStatus(): boolean {
+  if (
+    typeof __DEV__ !== 'undefined' &&
+    __DEV__ &&
+    String(Config.DISABLE_OPENID4VC_CREDENTIAL_STATUS_VERIFY ?? '').toLowerCase() === 'true'
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Best-effort detection of Credo / issuer errors related to credential status or revocation,
+ * for user-facing messaging when status verification is enabled.
+ */
+export function isOpenId4VcCredentialStatusFailure(error: unknown): boolean {
+  if (error === null || error === undefined) {
+    return false
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? `${error.message} ${'cause' in error && error.cause instanceof Error ? error.cause.message : ''}`
+        : String(error)
+
+  const normalized = message.toLowerCase()
+  const patterns = [
+    'revok',
+    'revocation',
+    'credential status',
+    'status list',
+    'statuslist',
+    'invalid status',
+    'credential is not active',
+    'not active',
+    'has been revoked',
+    'verification failed',
+    'status verification',
+  ]
+
+  return patterns.some((p) => normalized.includes(p))
+}

--- a/heka-wallet/app/src/credentials/useOpenIdHandlers.ts
+++ b/heka-wallet/app/src/credentials/useOpenIdHandlers.ts
@@ -27,6 +27,7 @@ import { PRE_AUTH_GRANT_LITERAL } from '@sphereon/oid4vci-common'
 import { useCallback } from 'react'
 
 import { extractOpenId4VcCredentialMetadata, setOpenId4VcCredentialMetadata } from './metadata'
+import { shouldVerifyOpenId4VcCredentialStatus } from './openId4VcCredentialStatus'
 import { OpenId4VcPresentationRequest } from './types'
 
 // Credential formats supported by the wallet
@@ -189,7 +190,7 @@ export const useOpenIdHandlers = () => {
         ...accessToken,
         clientId,
         credentialsToRequest: [offeredCredentialToRequest.id],
-        verifyCredentialStatus: false,
+        verifyCredentialStatus: shouldVerifyOpenId4VcCredentialStatus(),
         allowedProofOfPossessionSignatureAlgorithms: [JwaSignatureAlgorithm.EdDSA, JwaSignatureAlgorithm.ES256],
         credentialBindingResolver: async ({
           supportedDidMethods,

--- a/heka-wallet/app/src/localization/en/index.ts
+++ b/heka-wallet/app/src/localization/en/index.ts
@@ -195,7 +195,10 @@ const translation = {
     "EnterCredentialPIN": "Please enter credential PIN",
     "CredentialAddedToYourWallet": "Your credential is good to go now!",
     "CredentialOnTheWay": "Your credential is on the way.",
-    "IssuedBy": "Issued by"
+    "IssuedBy": "Issued by",
+    "StatusVerificationTitle": "Credential cannot be added",
+    "StatusVerificationMessage":
+      "This credential was revoked or its status could not be verified. For your security, it was not saved to your wallet."
   },
   "ProofRequest": {
     "RequestedInformation": "Requested information",

--- a/heka-wallet/app/src/localization/fr/index.ts
+++ b/heka-wallet/app/src/localization/fr/index.ts
@@ -195,7 +195,10 @@ const translation = {
     "EnterCredentialPIN": "Veuillez saisir le code PIN du certificat",
     "CredentialAddedToYourWallet": "Votre certificat est prêt à l'emploi !",
     "CredentialOnTheWay": "Votre certificat est en route.",
-    "IssuedBy": "Émis par"
+    "IssuedBy": "Émis par",
+    "StatusVerificationTitle": "Le certificat ne peut pas être ajouté",
+    "StatusVerificationMessage":
+      "Ce certificat a été révoqué ou son statut n'a pas pu être vérifié. Pour votre sécurité, il n'a pas été enregistré dans votre portefeuille."
   },
   "ProofRequest": {
     "RequestedInformation": "Informations demandées",

--- a/heka-wallet/app/src/localization/pt-br/index.ts
+++ b/heka-wallet/app/src/localization/pt-br/index.ts
@@ -195,7 +195,10 @@ const translation = {
     "EnterCredentialPIN": "Por favor, insira o PIN da credencial",
     "CredentialAddedToYourWallet": "Sua credencial está pronta para uso!",
     "CredentialOnTheWay": "Sua credencial está a caminho.",
-    "IssuedBy": "Emitido por"
+    "IssuedBy": "Emitido por",
+    "StatusVerificationTitle": "Não é possível adicionar a credencial",
+    "StatusVerificationMessage":
+      "Esta credencial foi revogada ou seu status não pôde ser verificado. Por segurança, ela não foi salva na sua carteira."
   },
   "ProofRequest": {
     "RequestedInformation": "Informações solicitadas",

--- a/heka-wallet/app/src/screens/OpenIdCredentialOffer.tsx
+++ b/heka-wallet/app/src/screens/OpenIdCredentialOffer.tsx
@@ -15,7 +15,13 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 
 import { CredentialOfferView } from '../components/views'
 import LoadingView from '../components/views/LoadingView'
-import { Credential, mapCredentialRecord, useCredentialRecordHelpers, useOpenIdHandlers } from '../credentials'
+import {
+  Credential,
+  isOpenId4VcCredentialStatusFailure,
+  mapCredentialRecord,
+  useCredentialRecordHelpers,
+  useOpenIdHandlers,
+} from '../credentials'
 import { OpenIdStackParams, Screens } from '../navigators/types'
 
 type CredentialOfferProps = StackScreenProps<OpenIdStackParams, Screens.OpenIdCredentialOffer>
@@ -69,11 +75,12 @@ export const OpenIdCredentialOffer: React.FC<CredentialOfferProps> = ({ navigati
         console.error(`Couldn't receive credential from OpenID4VCI offer`, {
           error,
         })
+        const statusRelated = isOpenId4VcCredentialStatusFailure(error)
         DeviceEventEmitter.emit(
           EventTypes.ERROR_ADDED,
           new BifoldError(
-            t('Error.Title1035'),
-            t('Error.Message1035'),
+            statusRelated ? t('CredentialOffer.StatusVerificationTitle') : t('Error.Title1035'),
+            statusRelated ? t('CredentialOffer.StatusVerificationMessage') : t('Error.Message1035'),
             (error as Error)?.message || t('Error.Unknown'),
             1035
           )


### PR DESCRIPTION
**Summary**

Enables `verifyCredentialStatus: true` by default for OpenID4VC credential offers in the wallet.

This ensures that revoked or invalid-status credentials are rejected or clearly surfaced to the user instead of being silently accepted — directly strengthening the trust model for **Hero Contributor Verification**.

### Changes

- Made credential status verification **default-on** via a new helper `shouldVerifyOpenId4VcCredentialStatus()`
- Added a safe dev-only escape hatch: `DISABLE_OPENID4VC_CREDENTIAL_STATUS_VERIFY=true` (only works in `__DEV__`)
- Added localized user-facing error messages for revocation / status verification failures
- Added unit tests covering default behavior, dev escape, and revoked credential handling
- Updated wallet README.md with documentation of the new default and escape flag

This change makes the wallet more secure by default while keeping development workflows flexible.

Related to LFX "Hero Contributor Verification" mentorship.
