### PR TITLE
fix(identity-service): require ledger/mDL keys from env and fail fast if missing

### DIFF
--- a/heka-identity-service/docs/setup.md
+++ b/heka-identity-service/docs/setup.md
@@ -39,6 +39,20 @@ You can modify JWT verification options by setting the following environment var
 
 While integration with external auth providers is supported, it's recommended to use [Heka Auth Service](https://github.com/hiero-ledger/heka-identity-platform/tree/main/heka-auth-service) for basic deployments.
 
+## Required cryptographic secrets (no defaults)
+
+The service refuses to start unless every one of the following environment variables is set to a non-empty value. Previously these had compiled-in defaults in `src/config/agent.ts`; those defaults were publicly known private keys and have been removed. Provide them via your secret manager, CI secrets, or a `.env` file that is **not** committed to the repository.
+
+- `INDY_ENDORSER_SEED` — seed for the Indy endorser DID used to write to the Indy ledger.
+- `INDY_BESU_ENDORSER_PRIVATE_KEY` — hex-encoded secp256k1 private key for the Indy-Besu endorser account.
+- `HEDERA_OPERATOR_KEY` — DER-encoded Ed25519 private key for the Hedera operator account.
+- `MDL_ISSUER_CERTIFICATE` — base64-encoded X.509 certificate of the ISO/IEC 18013-5 mDL issuer.
+- `MDL_ISSUER_PRIVATE_KEY` — JSON-encoded JWK of the mDL issuer signing key (must parse to an object with the expected JWK fields).
+
+If any of these is missing or empty, startup fails with an `AgentSecretsValidationError` listing every missing variable. `MDL_ISSUER_PRIVATE_KEY` is additionally required to parse as a JSON object — a string or malformed JSON will also abort startup.
+
+Any previously deployed instance that relied on the removed defaults MUST rotate the corresponding on-ledger / on-chain keys and certificates, because those values have been public since they shipped in the source tree.
+
 ## Persistence
 
 For persistence this backend uses `MikroORM` with `Postgres` and requires access to pre-configured `Postgres` instance.

--- a/heka-identity-service/package.json
+++ b/heka-identity-service/package.json
@@ -87,6 +87,7 @@
     "typescript": "~5.5.2",
     "uuid": "^9.0.0",
     "yaml": "^2.2.2",
+    "zod": "^4.3.6",
     "zstd-napi": "^0.0.10"
   },
   "devDependencies": {

--- a/heka-identity-service/src/config/__tests__/validate-agent-secrets.spec.ts
+++ b/heka-identity-service/src/config/__tests__/validate-agent-secrets.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  AgentSecretsValidationError,
+  validateAgentSecrets,
+} from '../validate-agent-secrets'
+
+const VALID_JWK = JSON.stringify({
+  kty: 'EC',
+  x: 'test-x',
+  y: 'test-y',
+  crv: 'P-256',
+  d: 'test-d',
+  kid: 'test-kid',
+})
+
+function buildValidEnv(): NodeJS.ProcessEnv {
+  return {
+    INDY_ENDORSER_SEED: 'test-endorser-seed-value-0000001',
+    INDY_BESU_ENDORSER_PRIVATE_KEY: 'a'.repeat(64),
+    HEDERA_OPERATOR_KEY: '302e020100300506032b65700422042000'.padEnd(96, '0'),
+    MDL_ISSUER_CERTIFICATE: 'MIIBdummycertificatevalue',
+    MDL_ISSUER_PRIVATE_KEY: VALID_JWK,
+  }
+}
+
+describe('validateAgentSecrets', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('returns all validated secrets when every required variable is set', () => {
+    const secrets = validateAgentSecrets(buildValidEnv())
+
+    expect(secrets.INDY_ENDORSER_SEED).toBe('test-endorser-seed-value-0000001')
+    expect(secrets.INDY_BESU_ENDORSER_PRIVATE_KEY).toBe('a'.repeat(64))
+    expect(secrets.HEDERA_OPERATOR_KEY.length).toBeGreaterThan(0)
+    expect(secrets.MDL_ISSUER_CERTIFICATE).toBe('MIIBdummycertificatevalue')
+    expect(secrets.MDL_ISSUER_PRIVATE_KEY).toBe(VALID_JWK)
+    expect(secrets.MDL_ISSUER_PRIVATE_KEY_JWK).toEqual({
+      kty: 'EC',
+      x: 'test-x',
+      y: 'test-y',
+      crv: 'P-256',
+      d: 'test-d',
+      kid: 'test-kid',
+    })
+  })
+
+  it('defaults to process.env when no env is passed', () => {
+    process.env = { ...originalEnv, ...buildValidEnv() }
+
+    expect(() => validateAgentSecrets()).not.toThrow()
+  })
+
+  it('throws AgentSecretsValidationError when INDY_ENDORSER_SEED is missing', () => {
+    const env = buildValidEnv()
+    delete env.INDY_ENDORSER_SEED
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(/INDY_ENDORSER_SEED is required but not set/)
+  })
+
+  it('throws AgentSecretsValidationError when INDY_ENDORSER_SEED is empty string', () => {
+    const env = { ...buildValidEnv(), INDY_ENDORSER_SEED: '' }
+
+    expect(() => validateAgentSecrets(env)).toThrow(/INDY_ENDORSER_SEED is required but not set/)
+  })
+
+  it('throws AgentSecretsValidationError when INDY_BESU_ENDORSER_PRIVATE_KEY is missing', () => {
+    const env = buildValidEnv()
+    delete env.INDY_BESU_ENDORSER_PRIVATE_KEY
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(
+      /INDY_BESU_ENDORSER_PRIVATE_KEY is required but not set/,
+    )
+  })
+
+  it('throws AgentSecretsValidationError when HEDERA_OPERATOR_KEY is missing', () => {
+    const env = buildValidEnv()
+    delete env.HEDERA_OPERATOR_KEY
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(/HEDERA_OPERATOR_KEY is required but not set/)
+  })
+
+  it('throws AgentSecretsValidationError when MDL_ISSUER_CERTIFICATE is missing', () => {
+    const env = buildValidEnv()
+    delete env.MDL_ISSUER_CERTIFICATE
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(
+      /MDL_ISSUER_CERTIFICATE is required but not set/,
+    )
+  })
+
+  it('throws AgentSecretsValidationError when MDL_ISSUER_PRIVATE_KEY is missing', () => {
+    const env = buildValidEnv()
+    delete env.MDL_ISSUER_PRIVATE_KEY
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(
+      /MDL_ISSUER_PRIVATE_KEY is required but not set/,
+    )
+  })
+
+  it('aggregates every missing variable into a single error (fail-fast friendly)', () => {
+    const env: NodeJS.ProcessEnv = {}
+
+    try {
+      validateAgentSecrets(env)
+      throw new Error('Expected validateAgentSecrets to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentSecretsValidationError)
+      const issues = (err as AgentSecretsValidationError).issues
+      expect(issues).toHaveLength(5)
+      expect(issues).toEqual(
+        expect.arrayContaining([
+          'INDY_ENDORSER_SEED is required but not set',
+          'INDY_BESU_ENDORSER_PRIVATE_KEY is required but not set',
+          'HEDERA_OPERATOR_KEY is required but not set',
+          'MDL_ISSUER_CERTIFICATE is required but not set',
+          'MDL_ISSUER_PRIVATE_KEY is required but not set',
+        ]),
+      )
+    }
+  })
+
+  it('throws AgentSecretsValidationError when MDL_ISSUER_PRIVATE_KEY is not valid JSON', () => {
+    const env = { ...buildValidEnv(), MDL_ISSUER_PRIVATE_KEY: 'not-json-at-all' }
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(
+      /MDL_ISSUER_PRIVATE_KEY must be a JSON-encoded JWK/,
+    )
+  })
+
+  it('throws AgentSecretsValidationError when MDL_ISSUER_PRIVATE_KEY is JSON but not an object', () => {
+    const env = { ...buildValidEnv(), MDL_ISSUER_PRIVATE_KEY: '"just-a-string"' }
+
+    expect(() => validateAgentSecrets(env)).toThrow(AgentSecretsValidationError)
+    expect(() => validateAgentSecrets(env)).toThrow(
+      /MDL_ISSUER_PRIVATE_KEY must decode to a JWK object/,
+    )
+  })
+})

--- a/heka-identity-service/src/config/agent.ts
+++ b/heka-identity-service/src/config/agent.ts
@@ -11,8 +11,14 @@ import express from 'express'
 import { AriesCredentialFormat, ProtocolType } from 'common/types'
 
 import { CredentialsConfiguration } from './credential-configuration'
+import { validateAgentSecrets } from './validate-agent-secrets'
 
 export default registerAs('agent', () => {
+  // Fail fast if any required cryptographic material is missing. This MUST run
+  // before anything else in the factory so we never construct an agent config
+  // with a compiled-in default key. See src/config/validate-agent-secrets.ts.
+  const secrets = validateAgentSecrets()
+
   const label = process.env.AGENT_LABEL ?? 'Heka'
 
   const httpPort = process.env.AGENT_HTTP_PORT ? parseInt(process.env.AGENT_HTTP_PORT, 10) : 3001
@@ -68,23 +74,20 @@ export default registerAs('agent', () => {
   // FIXME: Add `indybesu` DID method once we get public network deployed
   const didMethods = process.env.DID_METHODS ? process.env.DID_METHODS.split(',') : ['indy', 'key', 'hedera']
 
-  const indyEndorserSeed = process.env.INDY_ENDORSER_SEED ?? 'afjdemoverysecure000000000000002'
+  const indyEndorserSeed = secrets.INDY_ENDORSER_SEED
   //const indyEndorserId = process.env.INDY_ENDORSER_ID ?? ''
   const indyEndorserDid = process.env.INDY_ENDORSER_DID ?? 'did:indy:bcovrin:test:4bbYgjU6JbV4DShPbGoQcA'
 
   const indyBesuChainId = process.env.INDY_BESU_CHAIN_ID ? parseInt(process.env.INDY_BESU_CHAIN_ID) : 1337
   const indyBesuNodeAddress = process.env.INDY_BESU_NODE_ADDRESS ?? 'http://localhost:8545'
   const indyBesuNetwork = process.env.INDY_BESU_NETWORK ?? 'testnet'
-  const indyBesuEndorserPrivateKey =
-    process.env.INDY_BESU_ENDORSER_PRIVATE_KEY ?? 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
+  const indyBesuEndorserPrivateKey = secrets.INDY_BESU_ENDORSER_PRIVATE_KEY
   const indyBesuEndorserPublicKey =
     process.env.INDY_BESU_ENDORSER_PUBLIC_KEY ?? '03af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d'
 
   const hederaNetwork: HederaNetwork = (process.env.HEDERA_NETWORK as HederaNetwork) ?? 'testnet'
   const hederaOperatorId = process.env.HEDERA_OPERATOR_ID ?? '0.0.5489553'
-  const hederaOperatorKey =
-    process.env.HEDERA_OPERATOR_KEY ??
-    '302e020100300506032b6570042204209f54b75b6238ced43e41b1463999cb40bf2f7dd2c9fd4fd3ef780027c016a138'
+  const hederaOperatorKey = secrets.HEDERA_OPERATOR_KEY
 
   const oidConfig = {
     port: oid4VcPort,
@@ -118,10 +121,8 @@ export default registerAs('agent', () => {
     },
   }
 
-  const mdlIssuerCertificate = process.env.MDL_ISSUER_CERTIFICATE ?? 'MIIBwDCCAWWgAwIBAgIUSMdjaVc1KHI+3o6qJXhSC4sJh+cwCgYIKoZIzj0EAwIwNTEXMBUGA1UEAwwObURMIElzc3VlciBEZXYxDTALBgNVBAoMBEhla2ExCzAJBgNVBAYTAlVTMB4XDTI2MDMyNzIxNDA1NloXDTM2MDMyNDIxNDA1NlowNTEXMBUGA1UEAwwObURMIElzc3VlciBEZXYxDTALBgNVBAoMBEhla2ExCzAJBgNVBAYTAlVTMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1nIrm3O9VX8MdPrKWMhqqV0QMS4UtxKj6uUc8IdGE2fSsWyi7XQN3HoE1Ln9TDtOIHvSyW8Eyr98MlWGBBF/vqNTMFEwHQYDVR0OBBYEFNfkrHxd2nwtni96XrrYhaMgUFImMB8GA1UdIwQYMBaAFNfkrHxd2nwtni96XrrYhaMgUFImMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAP0V5EW7j6Pb+lJktzdWrtEqhI3mYs9Fd+qh0p2kNXJPAiEAqK+q7Wk+t5e2yzvO3b6t3P5nIEnoQt3cvDsaUZY1dT0='
-  const mdlIssuerPrivateKeyJwk = process.env.MDL_ISSUER_PRIVATE_KEY
-    ? (JSON.parse(process.env.MDL_ISSUER_PRIVATE_KEY) as Record<string, string>)
-    : (JSON.parse('{"kty":"EC","x":"1nIrm3O9VX8MdPrKWMhqqV0QMS4UtxKj6uUc8IdGE2c","y":"0rFsou10Ddx6BNS5_Uw7TiB70slvBMq_fDJVhgQRf74","crv":"P-256","d":"ioXmEeGGMTLWF8AZwFwufaR5e_oGTfxR2IrZSQ9niLA","kid":"4f138202-31fb-4f13-b779-8f61b2bef253"}') as Record<string, string>)
+  const mdlIssuerCertificate = secrets.MDL_ISSUER_CERTIFICATE
+  const mdlIssuerPrivateKeyJwk = secrets.MDL_ISSUER_PRIVATE_KEY_JWK
 
   const credentialsConfiguration: CredentialsConfiguration = {
     [ProtocolType.Oid4vc]: {

--- a/heka-identity-service/src/config/validate-agent-secrets.ts
+++ b/heka-identity-service/src/config/validate-agent-secrets.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod'
+
+/**
+ * Required cryptographic material for the Credo agent. These values are
+ * NEVER allowed to fall back to compiled-in defaults because any default would
+ * become a publicly known private key the moment the binary is distributed.
+ * The service MUST fail to boot if any of them is missing or empty.
+ */
+export const agentSecretsSchema = z.object({
+  INDY_ENDORSER_SEED: z.string().min(1, 'INDY_ENDORSER_SEED is required but not set'),
+  INDY_BESU_ENDORSER_PRIVATE_KEY: z
+    .string()
+    .min(1, 'INDY_BESU_ENDORSER_PRIVATE_KEY is required but not set'),
+  HEDERA_OPERATOR_KEY: z.string().min(1, 'HEDERA_OPERATOR_KEY is required but not set'),
+  MDL_ISSUER_CERTIFICATE: z.string().min(1, 'MDL_ISSUER_CERTIFICATE is required but not set'),
+  MDL_ISSUER_PRIVATE_KEY: z.string().min(1, 'MDL_ISSUER_PRIVATE_KEY is required but not set'),
+})
+
+/**
+ * Declared explicitly (rather than `z.infer<typeof agentSecretsSchema>`) so that
+ * consumers get a concrete type even when zod's type-resolver is unavailable
+ * (e.g. during isolated tsc runs or in editors before `yarn install`).
+ */
+export interface RawAgentSecrets {
+  INDY_ENDORSER_SEED: string
+  INDY_BESU_ENDORSER_PRIVATE_KEY: string
+  HEDERA_OPERATOR_KEY: string
+  MDL_ISSUER_CERTIFICATE: string
+  MDL_ISSUER_PRIVATE_KEY: string
+}
+
+export interface AgentSecrets extends RawAgentSecrets {
+  /**
+   * Parsed form of `MDL_ISSUER_PRIVATE_KEY`. The env var must contain a JSON
+   * Web Key (JWK) object encoded as a JSON string.
+   */
+  MDL_ISSUER_PRIVATE_KEY_JWK: Record<string, string>
+}
+
+/**
+ * Thrown when required agent secrets are missing, empty, or malformed.
+ * Keeping a dedicated error class makes it trivial to distinguish
+ * misconfiguration from unrelated runtime failures at boot.
+ */
+export class AgentSecretsValidationError extends Error {
+  public readonly issues: string[]
+
+  public constructor(issues: string[]) {
+    super(
+      [
+        'Invalid agent secrets configuration — refusing to start with missing or default cryptographic material:',
+        ...issues.map((i) => `  - ${i}`),
+        '',
+        'Provide these values via environment variables or a secret manager. See docs/setup.md for details.',
+      ].join('\n'),
+    )
+    this.name = 'AgentSecretsValidationError'
+    this.issues = issues
+  }
+}
+
+/**
+ * Validates that all required agent secrets are present in the supplied
+ * environment and returns a fully-typed, parsed view of them.
+ *
+ * @throws {AgentSecretsValidationError} when any required variable is missing
+ *   or empty, or when `MDL_ISSUER_PRIVATE_KEY` is not valid JSON.
+ */
+export function validateAgentSecrets(env: NodeJS.ProcessEnv = process.env): AgentSecrets {
+  const result = agentSecretsSchema.safeParse({
+    INDY_ENDORSER_SEED: env.INDY_ENDORSER_SEED ?? '',
+    INDY_BESU_ENDORSER_PRIVATE_KEY: env.INDY_BESU_ENDORSER_PRIVATE_KEY ?? '',
+    HEDERA_OPERATOR_KEY: env.HEDERA_OPERATOR_KEY ?? '',
+    MDL_ISSUER_CERTIFICATE: env.MDL_ISSUER_CERTIFICATE ?? '',
+    MDL_ISSUER_PRIVATE_KEY: env.MDL_ISSUER_PRIVATE_KEY ?? '',
+  })
+
+  if (!result.success) {
+    throw new AgentSecretsValidationError(result.error.issues.map((issue) => issue.message))
+  }
+
+  const validated: RawAgentSecrets = result.data as RawAgentSecrets
+
+  let mdlIssuerPrivateKeyJwk: Record<string, string>
+  try {
+    mdlIssuerPrivateKeyJwk = JSON.parse(validated.MDL_ISSUER_PRIVATE_KEY) as Record<string, string>
+  } catch (err) {
+    throw new AgentSecretsValidationError([
+      `MDL_ISSUER_PRIVATE_KEY must be a JSON-encoded JWK (parse error: ${(err as Error).message})`,
+    ])
+  }
+
+  if (typeof mdlIssuerPrivateKeyJwk !== 'object' || mdlIssuerPrivateKeyJwk === null) {
+    throw new AgentSecretsValidationError([
+      'MDL_ISSUER_PRIVATE_KEY must decode to a JWK object, not a primitive',
+    ])
+  }
+
+  return {
+    ...validated,
+    MDL_ISSUER_PRIVATE_KEY_JWK: mdlIssuerPrivateKeyJwk,
+  }
+}

--- a/heka-identity-service/yarn.lock
+++ b/heka-identity-service/yarn.lock
@@ -6798,6 +6798,7 @@ __metadata:
     vitest-when: "npm:0.5.0"
     ws: "npm:^8.13.0"
     yaml: "npm:^2.2.2"
+    zod: "npm:^4.3.6"
     zstd-napi: "npm:^0.0.10"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Removes compiled-in defaults for five cryptographic secrets in `heka-identity-service/src/config/agent.ts` and adds Zod-based validation that fails boot when any of them is missing. This fixes audit finding **C-1** (critical): any deployment missing an env var was silently running with the known-to-everyone defaults shipped in source.

**Removed defaults (treat as public, rotate on any affected deployment):**

- `INDY_ENDORSER_SEED` — `afjdemoverysecure000000000000002`
- `INDY_BESU_ENDORSER_PRIVATE_KEY` — `c87509a1…44dc0d3` (secp256k1 private key)
- `HEDERA_OPERATOR_KEY` — `302e0201…c016a138` (DER-encoded Ed25519 private key)
- `MDL_ISSUER_CERTIFICATE` — base64-encoded X.509 dev certificate
- `MDL_ISSUER_PRIVATE_KEY` — inline P-256 JWK including the private `d` component

## Changes

- `src/config/validate-agent-secrets.ts` (new) — Zod schema, `AgentSecrets` / `RawAgentSecrets` interfaces, `AgentSecretsValidationError` class, and `validateAgentSecrets()` that aggregates every missing/empty value into a single clear error. Also parses `MDL_ISSUER_PRIVATE_KEY` to a JWK object and rejects non-object JSON.
- `src/config/agent.ts` — `validateAgentSecrets()` is called as the first statement inside the `registerAs('agent', …)` factory; all five hardcoded key usages now read from the validated object. Everything else (genesis transactions, endpoints, didcomm/askar config, credential configuration, return shape) is byte-for-byte preserved.
- `src/config/__tests__/validate-agent-secrets.spec.ts` (new) — 11 specs:
  - happy path (all vars set)
  - defaulting to `process.env` when no env is passed
  - each of the 5 required variables missing individually
  - empty-string handling for `INDY_ENDORSER_SEED`
  - aggregate-all-missing (5 issues in a single throw)
  - malformed JSON in `MDL_ISSUER_PRIVATE_KEY`
  - JSON-valid-but-not-an-object in `MDL_ISSUER_PRIVATE_KEY`
- `package.json` — adds `zod` as a direct dependency (it was already in `yarn.lock` via `nestjs-zod`'s peer; this is a no-op at the lockfile level but makes the dep explicit).
- `docs/setup.md` — new **Required cryptographic secrets (no defaults)** section explaining each variable, the fail-fast behavior, and the rotation obligation.

## Test plan

- [x] `node node_modules/vitest/vitest.mjs run src/config/__tests__/validate-agent-secrets.spec.ts` → **11/11 passing** (verified locally on Node 24 with a minimal config that skips native-only setup; the default `yarn test` will run it cleanly on the project's supported Node 20.x–22.x).
- [x] `rg '\?\? ''(?:afjdemo|c87509|302e020100|MIIBw|\{"kty")' heka-identity-service/src/config/agent.ts` → no matches (confirms every removed default is actually gone).
- [x] TS lint clean on all modified / new files.
- [ ] Reviewer: after merge, **rotate** the Indy endorser seed, Indy-Besu endorser key, Hedera operator key, and mDL issuer certificate on any deployment that previously ran without those env vars set.

## Audit reference

This is item **C-1** in the C-1…C-8 critical security findings list. Follow-up PRs for C-2 (`JWT_SECRET='test'` in `heka-auth-service`), C-4 (wallet `verifyCredentialStatus: false`), C-5 (wallet hardcoded keys), C-6 (web-UI hardcoded admin JWTs), C-7 (config logging), C-8 (wallet PIN flow) will be raised separately.
