### PR TITLE
fix(auth): update demo user token expiry to 1 year and return true expiry (#28)

### DIFF
--- a/heka-auth-service/src/core/config/configs/jwt.config.ts
+++ b/heka-auth-service/src/core/config/configs/jwt.config.ts
@@ -15,7 +15,7 @@ export const jwtConfigDefaults = {
   secret: 'test',
   accessExpiry: 60 * 60, // 1h
   refreshExpiry: 86400, // 24h
-  demoUserTokenExpiry: 1000 * 24 * 60 * 60 * 30 * 12, // ~1 years validity for Demo User
+  demoUserTokenExpiry: 60 * 60 * 24 * 365, // ~1 years validity for Demo User
 }
 
 export class JwtConfig {

--- a/heka-auth-service/src/oauth/oauth.service.ts
+++ b/heka-auth-service/src/oauth/oauth.service.ts
@@ -165,7 +165,7 @@ export class OAuthService {
 
     return {
       token,
-      expiresIn: this.configService.jwtConfig.accessExpiry,
+      expiresIn: accessTokenExpiresIn,
     }
   }
 


### PR DESCRIPTION
# Body

Fixes #28

### Description
The initial demo user token expiration was erroneously configured to use ~986 years validity (`1000 * 24 * 60 * 60 * 30 * 12` seconds) despite the comment noting a ~1-year validity intention. This pull request resolves the miscalculation, configuring the demo token expiration explicitly to 1 year (`60 * 60 * 24 * 365`). 

Additionally, previously the authentication login response would return the default short-lived access duration under the `expiresIn` field even though the internally signed token actually used the demo expiration. This PR fixes this discrepancy so that the login response now correctly reflects the effective token validity.

### Changes Made
- Updated `demoUserTokenExpiry` in `jwt.config.ts` from ~986 years to precisely 1 year (`60 * 60 * 24 * 365` seconds).
- Modified the `/login` logic in `oauth.service.ts` to surface the effective `accessTokenExpiresIn` value rather than the static `jwtConfig.accessExpiry`.
- Ensured commits are signed properly.
