### PR TITLE
feat(health): expand monitoring in identity and auth services and enable unhandled rejection logging

### DIFF
--- a/heka-auth-service/src/health/health.controller.ts
+++ b/heka-auth-service/src/health/health.controller.ts
@@ -1,7 +1,13 @@
 import { ConfigService } from '@config'
 import { Controller, Get, Logger } from '@nestjs/common'
 import { ApiOperation, ApiTags } from '@nestjs/swagger'
-import { HealthCheck, HealthCheckResult, HealthCheckService, MemoryHealthIndicator } from '@nestjs/terminus'
+import {
+  HealthCheck,
+  HealthCheckResult,
+  HealthCheckService,
+  MemoryHealthIndicator,
+  MikroOrmHealthIndicator,
+} from '@nestjs/terminus'
 
 @ApiTags('Health')
 @Controller('health')
@@ -11,6 +17,7 @@ export class HealthController {
   public constructor(
     private readonly healthCheckService: HealthCheckService,
     private readonly memoryHealthIndicator: MemoryHealthIndicator,
+    private readonly mikroOrmHealthIndicator: MikroOrmHealthIndicator,
     private readonly configService: ConfigService,
   ) {
     this.logger.verbose('constructor<>')
@@ -26,6 +33,7 @@ export class HealthController {
     return await this.healthCheckService.check([
       () => this.memoryHealthIndicator.checkHeap('memory_heap', memoryHeapThresholdMb * 1024 * 1024),
       () => this.memoryHealthIndicator.checkRSS('memory_rss', memoryRssThresholdMb * 1024 * 1024),
+      () => this.mikroOrmHealthIndicator.pingCheck('database'),
     ])
   }
 }

--- a/heka-identity-service/src/app.starter.ts
+++ b/heka-identity-service/src/app.starter.ts
@@ -153,9 +153,9 @@ export async function startApp(app: INestApplication, { withSwaggerUi }: { withS
 
   app.enableShutdownHooks()
 
-  // process.on('unhandledRejection', (err) => {
-  //   logger.error(`Unhandled Rejection: ${err}`)
-  // })
+  process.on('unhandledRejection', (err) => {
+    logger.error(`Unhandled Rejection: ${err}`)
+  })
 
   // Recreate OCA files for Aries
   await app.get(OCAFilesService)?.run()

--- a/heka-identity-service/src/health/health.controller.ts
+++ b/heka-identity-service/src/health/health.controller.ts
@@ -1,8 +1,15 @@
 import { Controller, Get, Inject } from '@nestjs/common'
 import { ConfigType } from '@nestjs/config'
 import { ApiOperation, ApiTags } from '@nestjs/swagger'
-import { HealthCheck, HealthCheckResult, HealthCheckService, MemoryHealthIndicator } from '@nestjs/terminus'
+import {
+  HealthCheck,
+  HealthCheckResult,
+  HealthCheckService,
+  MemoryHealthIndicator,
+  MikroOrmHealthIndicator,
+} from '@nestjs/terminus'
 
+import { Agent, AGENT_TOKEN } from 'common/agent'
 import { InjectLogger, Logger } from 'common/logger'
 import HealthConfig from 'config/health'
 
@@ -12,6 +19,9 @@ export class HealthController {
   public constructor(
     private readonly healthCheckService: HealthCheckService,
     private readonly memoryHealthIndicator: MemoryHealthIndicator,
+    private readonly mikroOrmHealthIndicator: MikroOrmHealthIndicator,
+    @Inject(AGENT_TOKEN)
+    private readonly agent: Agent,
     @InjectLogger(HealthController)
     private readonly logger: Logger,
     @Inject(HealthConfig.KEY)
@@ -31,6 +41,10 @@ export class HealthController {
     const checkResult = await this.healthCheckService.check([
       () => this.memoryHealthIndicator.checkHeap('memory_heap', memoryHeapThresholdMb * 1024 * 1024),
       () => this.memoryHealthIndicator.checkRSS('memory_rss', memoryRssThresholdMb * 1024 * 1024),
+      () => this.mikroOrmHealthIndicator.pingCheck('database'),
+      () => ({
+        agent: this.agent.isInitialized ? { status: 'up' } : { status: 'down' },
+      }),
     ])
     logger.traceObject({ checkResult })
 

--- a/heka-identity-service/src/health/health.module.ts
+++ b/heka-identity-service/src/health/health.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common'
 import { TerminusModule } from '@nestjs/terminus'
 
+import { AgentModule } from 'common/agent'
+
 import { HealthController } from './health.controller'
 
 @Module({
-  imports: [TerminusModule],
+  imports: [TerminusModule, AgentModule],
   controllers: [HealthController],
 })
 export class HealthModule {}


### PR DESCRIPTION

**Description**:

This PR expands the production monitoring capabilities of the Heka Identity Platform by enhancing health checks and observability.

* Add PostgreSQL connectivity monitoring to `heka-identity-service` and `heka-auth-service` via MikroORM.
* Add SSI Agent initialization status to the identity service health endpoint.
* Enable `unhandledRejection` logging in the identity service to capture background promise failures.
* Update `HealthModule` dependencies to support Agent injection.



Fixes #50 

**Notes for reviewer**:
The `/health` endpoint now provides a more comprehensive view of the system state, returning 503 if critical dependencies like the database are unreachable.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
