### PR TITLE
fix(web-ui): allow clearing uncontrolled text input

### DIFF
--- a/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.test.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.test.tsx
@@ -2,10 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 jest.mock('@/shared/assets/icons/visibility-off.svg', () => 'visibility-off.svg');
-jest.mock(
-  '@/shared/assets/icons/visibility-outline.svg',
-  () => 'visibility-outline.svg',
-);
+jest.mock('@/shared/assets/icons/visibility-outline.svg', () => 'visibility-outline.svg');
 
 import { TextInputUncontrolled } from './TextInput';
 
@@ -25,5 +22,24 @@ describe('TextInputUncontrolled', () => {
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveBeenLastCalledWith('abc');
+  });
+
+  test('propagates empty value when user clears input', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <TextInputUncontrolled
+        label="Search"
+        initValue="abc"
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('Search');
+    await user.clear(input);
+
+    expect((input as HTMLInputElement).value).toBe('');
+    expect(onChange).toHaveBeenLastCalledWith('');
   });
 });

--- a/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.tsx
@@ -102,16 +102,14 @@ export function TextInputUncontrolled({
   initValue,
   onChange,
 }: TextInputUncontrolledProps) {
-  const [value, setValue] = useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string>('');
 
   useEffect(() => {
-    setValue(initValue);
+    setValue(initValue ?? '');
   }, [initValue]);
 
   const onChangeHandler = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      if (!event.target.value) return;
-
       setValue(event.target.value);
       if (onChange) onChange(event.target.value);
     },


### PR DESCRIPTION
Handle empty-string updates in `TextInputUncontrolled` and add a regression test to verify clear-to-empty behavior.

**Description**:
This fixes a bug where clearing an input did not propagate `''` and left stale UI state.  
It also removes an uncontrolled-to-controlled transition risk by normalizing the local state initialization.

* Allow empty-string updates in `TextInputUncontrolled`
* Initialize uncontrolled input state with `''` and normalize `initValue` via `?? ''`
* Add a regression unit test covering clear-to-empty behavior

**Related issue(s)**:

Fixes #53 

**Notes for reviewer**:
- Verified with:
  - `yarn test:unit --runTestsByPath src/shared/ui/TextInput/TextInput.test.tsx`
- Test confirms clearing input now sets value to `''` and calls `onChange('')`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)