### PR TITLE
fix(web-ui): remove hardcoded JWT tokens from source code

### DIFF
--- a/heka-identity-service-web-ui/src/const/user.ts
+++ b/heka-identity-service-web-ui/src/const/user.ts
@@ -5,15 +5,9 @@ export const mainDidMethod = 'key';
 export const userRole = 'Admin';
 
 export const demoUser = {
-  did:
-    process.env.REACT_APP_DEMO_USER_DID ??
-    'did:key:z6MkmSoL4GCTkBtdL7ruiqaqtrijkGpqPPk3DQPY65GndM1j',
-  accessToken:
-    process.env.REACT_APP_DEMO_USER_ACCESS_TOKEN ??
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJBZG1pbiJdLCJuYW1lIjoiZGVtbyIsInR5cGUiOiJhY2Nlc3MiLCJpYXQiOjE3Mjc3MDg0NDUsImV4cCI6MzI4MzE3MDg0NDUsImF1ZCI6IkRTUiBHZW5lcmljIEFnZW5jeSIsImlzcyI6IkRTUiIsInN1YiI6IjJmOWM0MTkxLTQ3NzktNGNmMi1iMmFiLTVlNTg1M2YxNDVjNyJ9.vIqIx37zo3oFWjq0g1YZHbfp-hFYesqv5Ax9DPhVwZs',
-  refreshToken:
-    process.env.REACT_APP_DEMO_USER_REFRESH_TOKEN ??
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3Mjc3MDg0NDUsImV4cCI6MTgxNDEwODQ0NSwiYXVkIjoiRFNSIEdlbmVyaWMgQWdlbmN5IiwiaXNzIjoiRFNSIiwic3ViIjoiMmY5YzQxOTEtNDc3OS00Y2YyLWIyYWItNWU1ODUzZjE0NWM3IiwianRpIjoiOGE0MGUwYTUtMGRkOS00YjI5LWE0NmMtN2FjZGE1MmZiYmFiIn0.5jaq44p4EQpu0P3wEX-wiB3SfbWrrJQqBamkPX-1UeM',
+  did: process.env.REACT_APP_DEMO_USER_DID ?? '',
+  accessToken: process.env.REACT_APP_DEMO_USER_ACCESS_TOKEN ?? '',
+  refreshToken: process.env.REACT_APP_DEMO_USER_REFRESH_TOKEN ?? '',
 };
 
 export const baseDisplayMetadata = {

--- a/heka-identity-service-web-ui/src/shared/api/config/demoApi.ts
+++ b/heka-identity-service-web-ui/src/shared/api/config/demoApi.ts
@@ -5,6 +5,6 @@ import { demoUser } from '@/const/user';
 export const $agencyDemoApi = axios.create({
   baseURL: `${process.env.REACT_APP_AGENCY_ENDPOINT}`,
   headers: {
-    Authorization: `Bearer ${demoUser.accessToken}`,
+    ...(demoUser.accessToken ? { Authorization: `Bearer ${demoUser.accessToken}` } : {}),
   },
 });


### PR DESCRIPTION
Real signed JWT tokens were hardcoded as fallback values in src/const/user.ts. The access token had an Admin role claim and a far-future expiry, and was actively used in two places at runtime. token.ts fell back to it when localStorage was empty, and demoApi.ts baked it into every axios request header unconditionally.

Fixes #55

**Changes**

- `src/const/user.ts`: replaced hardcoded token strings with empty string fallbacks
- `src/shared/api/config/demoApi.ts`: added a guard so the Authorization header is only set when accessToken is non-empty

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)