### PR TITLE
fix(heka-auth-service): replace empty .catch() with await in bootstrap

### DIFF
--- a/heka-auth-service/src/main.ts
+++ b/heka-auth-service/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
     bufferLogs: true,
     bodyParser: true,
   })
-  void MainModule.bootstrap(app).catch()
+  await MainModule.bootstrap(app)
 }
 
 void bootstrap()


### PR DESCRIPTION
The bootstrap call in main.ts used .catch() with no argument, which silently discards any error thrown during startup. If the DB is unreachable or the port is in use, the process stays alive doing nothing.

Fixes #59

**Changes**
- `src/main.ts` :  replaced `void MainModule.bootstrap(app).catch()` with `await MainModule.bootstrap(app)` so startup failures propagate naturally

**Checklist**
- [x] Documented (Code comments, README, etc.)