### PR TITLE
feat(web-ui): add debounce to Search input handler

### DIFF
--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
@@ -1,17 +1,43 @@
+import { useCallback, useEffect, useRef } from 'react';
+
 import { TextInputUncontrolled } from '@/shared/ui/TextInput';
 
 import * as cls from './Search.module.scss';
 
+const DEBOUNCE_DELAY = 300;
+
 interface SearchProps {
-  onSearch: () => void;
+  onSearch: (value: string) => void;
 }
 
 export const Search = ({ onSearch }: SearchProps) => {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => {
+        onSearch(value);
+      }, DEBOUNCE_DELAY);
+    },
+    [onSearch],
+  );
+
   return (
     <div className={cls.SearchWrapper}>
       <TextInputUncontrolled
         label="Search"
-        onChange={onSearch} // TODO: use debounce
+        onChange={handleChange}
       />
     </div>
   );


### PR DESCRIPTION
Adds a small debounce to the `Search` input handler so `onSearch` is not called on every keypress.

* Update `SearchProps` so `onSearch` receives the current input value
* Add a 300ms debounce using `useRef` and `setTimeout`
* Clear the pending timer on unmount
* Replace the direct `onChange={onSearch}` call with a debounced handler

**Related issue(s)**:

Fixes #57

**Notes for reviewer**:

All changes are in `heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx`.

The previous implementation passed `onSearch` directly to `TextInputUncontrolled`, so the callback fired on every keystroke. This change delays the callback slightly and only calls it after the user stops typing for 300ms.

No new dependencies were added.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)