### PR TITLE
test: expand critical auth and web-ui coverage

### DIFF
--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -87,4 +87,32 @@ describe('E2E authorization', () => {
 
     expect(revokeTokenResponse.status).toBe(205)
   })
+
+  test('login fails with wrong password', async () => {
+    const user = newUser()
+    const createUserResponse = await request(app)
+      .post('/api/v1/user/register')
+      .send({
+        name: user.name,
+        password: user.password,
+        role: UserRole.Issuer,
+      } satisfies RegisterUserRequest)
+
+    expect(createUserResponse.status).toBe(201)
+
+    const loginUserResponse = await request(app)
+      .post('/api/v1/oauth/token')
+      .send({
+        name: user.name,
+        password: 'WrongPassword123!',
+      } satisfies LoginRequest)
+
+    expect(loginUserResponse.status).toBe(401)
+  })
+
+  test('profile endpoint requires authentication', async () => {
+    const response = await request(app).get('/api/v1/user/profile')
+
+    expect(response.status).toBe(401)
+  })
 })

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@/shared/assets/icons/visibility-off.svg', () => 'visibility-off.svg');
+jest.mock(
+  '@/shared/assets/icons/visibility-outline.svg',
+  () => 'visibility-outline.svg',
+);
+
+import { Search } from './Search';
+
+describe('Search', () => {
+  test('triggers onSearch callback on input changes', async () => {
+    const user = userEvent.setup();
+    const onSearch = jest.fn();
+
+    render(<Search onSearch={onSearch} />);
+
+    await user.type(screen.getByPlaceholderText('Search'), 'ab');
+
+    expect(onSearch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.test.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/TextInput/TextInput.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@/shared/assets/icons/visibility-off.svg', () => 'visibility-off.svg');
+jest.mock(
+  '@/shared/assets/icons/visibility-outline.svg',
+  () => 'visibility-outline.svg',
+);
+
+import { TextInputUncontrolled } from './TextInput';
+
+describe('TextInputUncontrolled', () => {
+  test('invokes onChange on typed input', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <TextInputUncontrolled
+        label="Search"
+        onChange={onChange}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText('Search'), 'abc');
+
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenLastCalledWith('abc');
+  });
+});


### PR DESCRIPTION

**Description**:
Expand automated coverage for critical auth and web-ui paths to reduce regression risk in core flows.

* Add negative auth e2e test for invalid login credentials
* Add auth e2e test to verify profile endpoint requires authentication
* Add unit test for `TextInputUncontrolled` callback behavior
* Add unit test for `Search` callback trigger behavior

**Related issue(s)**:

Fixes #65 

**Notes for reviewer**:
Verification commands:
```bash
cd heka-auth-service
yarn test --runInBand
```

```bash
cd heka-identity-service-web-ui
yarn test:unit --runInBand
```

Observed results:
- Auth service: 1 suite, 3 tests passing
- Web UI: 3 suites, 7 tests passing


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
