### PR TITLE
fix(security): remove JWT_SECRET 'test' default — fail-fast at boot (C-2)

### DIFF
--- a/heka-auth-service/docker-compose.dev.yml
+++ b/heka-auth-service/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
       - DB_PASSWORD=heka1
       - JWT_ISSUER=Heka
       - JWT_AUDIENCE=Heka Identity Service
-      - JWT_SECRET=test
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set in your shell environment (min 32 chars). Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"}
       - JWT_ACCESS_EXPIRY=3600
       - JWT_REFRESH_EXPIRY=86400
       - DEMO_USER=demo

--- a/heka-auth-service/docker-compose.yml
+++ b/heka-auth-service/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - DB_PASSWORD=heka1
       - JWT_ISSUER=Heka
       - JWT_AUDIENCE=Heka Identity Service
-      - JWT_SECRET=test
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set in your shell environment (min 32 chars). Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"}
       - JWT_ACCESS_EXPIRY=3600
       - JWT_REFRESH_EXPIRY=86400
       - DEMO_USER=demo

--- a/heka-auth-service/env/.env
+++ b/heka-auth-service/env/.env
@@ -15,7 +15,8 @@ DB_PASSWORD=heka1
 
 JWT_ISSUER=Heka
 JWT_AUDIENCE=Heka Identity Service
-JWT_SECRET=test
+# Required: generate with → node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+JWT_SECRET=REPLACE_WITH_YOUR_SECRET_MIN_32_CHARS
 JWT_ACCESS_EXPIRY=3600
 JWT_REFRESH_EXPIRY=86400
 

--- a/heka-auth-service/src/core/config/configs/jwt.config.ts
+++ b/heka-auth-service/src/core/config/configs/jwt.config.ts
@@ -12,7 +12,6 @@ export enum JwtConfigKeys {
 export const jwtConfigDefaults = {
   issuer: 'Heka',
   audience: 'Heka Identity Service',
-  secret: 'test',
   accessExpiry: 60 * 60, // 1h
   refreshExpiry: 86400, // 24h
   demoUserTokenExpiry: 60 * 60 * 24 * 365, // ~1 year validity for Demo User
@@ -41,9 +40,18 @@ export class JwtConfig {
 
   public constructor(configuration?: Record<string, any>) {
     const env = configuration ?? process.env
+
+    const secret = env[JwtConfigKeys.secret] as string | undefined
+    if (!secret || secret.length < 32) {
+      throw new Error(
+        '[heka-auth-service] JWT_SECRET env var must be set to a random string of at least 32 characters. ' +
+          "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+      )
+    }
+
     this.issuer = env[JwtConfigKeys.issuer] || jwtConfigDefaults.issuer
     this.audience = env[JwtConfigKeys.audience] || jwtConfigDefaults.audience
-    this.secret = env[JwtConfigKeys.secret] || jwtConfigDefaults.secret
+    this.secret = secret
 
     this.accessExpiry = env[JwtConfigKeys.accessExpiry]
       ? parseInt(env[JwtConfigKeys.accessExpiry])

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -17,6 +17,10 @@ describe('E2E authorization', () => {
   let app: Server
 
   beforeAll(async () => {
+    // JWT_SECRET must be at least 32 chars before the NestJS app module compiles.
+    // Use ??= so a value injected by the CI environment is preserved as-is.
+    process.env.JWT_SECRET ??= 'testsecrettestsecrettestsecretXX'
+
     const orm = await initializeMikroOrm()
     ormSchemaGenerator = orm.getSchemaGenerator()
 

--- a/heka-identity-service/src/config/jwt.ts
+++ b/heka-identity-service/src/config/jwt.ts
@@ -1,13 +1,20 @@
 import { registerAs } from '@nestjs/config'
 import { JwtModuleOptions } from '@nestjs/jwt'
 
-export default registerAs(
-  'jwt',
-  (): JwtModuleOptions => ({
-    secret: process.env.JWT_SECRET || 'test',
+export default registerAs('jwt', (): JwtModuleOptions => {
+  const secret = process.env.JWT_SECRET
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      '[heka-identity-service] JWT_SECRET env var must be set to a random string of at least 32 characters. ' +
+        "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+    )
+  }
+
+  return {
+    secret,
     verifyOptions: {
       issuer: process.env.JWT_VERIFY_OPTIONS_ISSUER || 'Heka',
       audience: process.env.JWT_VERIFY_OPTIONS_AUDIENCE || 'Heka Identity Service',
     },
-  }),
-)
+  }
+})

--- a/heka-identity-service/test/helpers/jwt.ts
+++ b/heka-identity-service/test/helpers/jwt.ts
@@ -33,7 +33,7 @@ export async function createAuthToken(userId: string, role: Role, orgId?: string
     payload.org_id = orgId
   }
 
-  const secret = 'test'
+  const secret = process.env.JWT_SECRET ?? 'testsecrettestsecrettestsecretXX'
 
   const options: SignOptions = {
     subject: userId,

--- a/heka-identity-service/test/vitest.setup.ts
+++ b/heka-identity-service/test/vitest.setup.ts
@@ -1,3 +1,8 @@
+// JWT_SECRET must be present before any test module imports src/config/jwt.ts
+// (which throws at boot when the secret is missing or shorter than 32 chars).
+// Using ??= preserves a value already injected by the CI environment.
+process.env.JWT_SECRET ??= 'testsecrettestsecrettestsecretXX'
+
 // Vitest runs each test file in an isolated src-module graph, but keeps
 // `node_modules` modules cached across files. `@mikro-orm/core` keeps a
 // static `MetadataStorage.metadata` map that accumulates registered


### PR DESCRIPTION
## Summary

- **Audit item C-2** — `JWT_SECRET` defaulted to the literal string `'test'` in both `heka-auth-service` and `heka-identity-service`. Any deployment that omitted the env var ran with a publicly-known signing secret, allowing an attacker to forge valid admin JWTs for either service.
- Both services now **throw a clear `Error` at startup** when `JWT_SECRET` is absent or shorter than 32 characters, so the failure is immediate and impossible to miss rather than silently insecure.
- Compose files use `${JWT_SECRET:?…}` so `docker compose up` also fails fast before the container even starts.

## Files changed

| File | What changed |
|---|---|
| `heka-auth-service/src/core/config/configs/jwt.config.ts` | Removed `secret: 'test'` from `jwtConfigDefaults`; added fail-fast guard in `JwtConfig` constructor |
| `heka-identity-service/src/config/jwt.ts` | Replaced `\|\| 'test'` fallback with fail-fast guard in `registerAs` factory |
| `heka-auth-service/env/.env` | Replaced `JWT_SECRET=test` with placeholder + generation hint comment |
| `heka-auth-service/docker-compose.yml` | `JWT_SECRET=${JWT_SECRET:?...}` — compose fails fast when host var is unset |
| `heka-auth-service/docker-compose.dev.yml` | Same `:?` substitution |
| `heka-identity-service/test/vitest.setup.ts` | `process.env.JWT_SECRET ??= '<32-char test value>'` before any module imports |
| `heka-identity-service/test/helpers/jwt.ts` | Use `process.env.JWT_SECRET ?? '<32-char test value>'` so test JWTs match the app |
| `heka-auth-service/test/authorization.e2e.test.ts` | Set `JWT_SECRET` in `beforeAll` before `startTestApp()` compiles the module |

## How to generate a real secret

```bash
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
```

Set the output as `JWT_SECRET` in your deployment secret manager, CI secret store, or local `.env` (which should be gitignored).

## Test plan

- [ ] `heka-identity-service`: `node_modules/.bin/tsc --noEmit -p tsconfig.src.json` passes (exit 0)
- [ ] `heka-auth-service`: no linter errors on changed files
- [ ] Start `heka-auth-service` **without** `JWT_SECRET` set → process exits immediately with message:
  `[heka-auth-service] JWT_SECRET env var must be set to a random string of at least 32 characters.`
- [ ] Start `heka-identity-service` **without** `JWT_SECRET` set → same fail-fast error
- [ ] `docker compose up` on `docker-compose.yml` without `JWT_SECRET` in host shell → compose exits with the `:?` error message
- [ ] Set `JWT_SECRET` to a 32+ char value and confirm both services start normally
- [ ] Run `heka-auth-service` e2e tests → `authorization.e2e.test.ts` passes (JWT_SECRET set in `beforeAll`)
- [ ] Run `heka-identity-service` vitest suite → all tests pass (JWT_SECRET set in `vitest.setup.ts`)

## Related

- Closes audit item **C-2** from the ongoing security audit
- Companion to PR #44 (which removed hardcoded crypto secrets from `agent.ts`)
- Remaining open items: C-5 (wallet hardcoded keys), C-6 (web-UI admin JWTs), C-7 (secrets in logs), C-8 (wallet PIN flow)