### PR TITLE
fix(build): restore clean build in heka-identity-service

### DIFF
--- a/heka-identity-service/package.json
+++ b/heka-identity-service/package.json
@@ -87,6 +87,7 @@
     "typescript": "~5.5.2",
     "uuid": "^9.0.0",
     "yaml": "^2.2.2",
+    "zod": "^4.3.6",
     "zstd-napi": "^0.0.10"
   },
   "devDependencies": {

--- a/heka-identity-service/src/common/auth/jwt.strategy.ts
+++ b/heka-identity-service/src/common/auth/jwt.strategy.ts
@@ -20,7 +20,10 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     jwtConfig: ConfigType<typeof JwtConfig>,
   ) {
     const strategyOptions: StrategyOptions = {
-      secretOrKey: jwtConfig.secret,
+      // JwtConfig always resolves `secret` to a string (env var or fallback).
+      // passport-jwt expects `string | Buffer`, while `jwt.Secret` also includes KeyObject.
+      // Narrowing to `string` is safe and avoids TS2322.
+      secretOrKey: jwtConfig.secret as string,
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       jsonWebTokenOptions: jwtConfig.verifyOptions,
     }

--- a/heka-identity-service/yarn.lock
+++ b/heka-identity-service/yarn.lock
@@ -6798,6 +6798,7 @@ __metadata:
     vitest-when: "npm:0.5.0"
     ws: "npm:^8.13.0"
     yaml: "npm:^2.2.2"
+    zod: "npm:^4.3.6"
     zstd-napi: "npm:^0.0.10"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Summary

Fixes a build-blocking TypeScript error in `heka-identity-service` and restores a clean build on fresh setups.

---

### Problem

A fresh clone fails to compile due to:

```
TS2322: Type 'KeyObject' is not assignable to type 'string | Buffer'
```

Additionally, the project fails due to a missing `zod` dependency required by `nestjs-zod`.

---

### Root Cause

* `jwtConfig.secret` is typed as `jwt.Secret`, which includes `KeyObject`
* `passport-jwt` expects `string | Buffer`
* This mismatch causes a TypeScript compilation failure

Separately, `zod` is required but not listed in dependencies.

---

### Fix

* Narrowed `jwtConfig.secret` to `string` in `jwt.strategy.ts`
* Added missing `zod` dependency to `package.json`

---

### Why this is safe

* `JwtConfig` always resolves `secret` to a string (env var or fallback)
* No runtime behavior is changed (type-level fix only)
* Dependency addition aligns with existing usage (`nestjs-zod`)

---

### Result

* `npm install` works without missing dependencies
* `npm run build` completes successfully
* Contributors can clone and build the project without additional fixes

---

### Validation

```bash
rm -rf node_modules package-lock.json
npm install
npm run build
```

Build completes with zero errors.

---

### Related Issue

Closes #71
