### PR TITLE
fix(auth): use configured refresh expiry

### DIFF
--- a/heka-auth-service/src/oauth/oauth.service.ts
+++ b/heka-auth-service/src/oauth/oauth.service.ts
@@ -173,7 +173,7 @@ export class OAuthService {
     user: User,
     accessToken: string,
   ): Promise<{ token: string; expiresIn: number }> => {
-    const expiresIn = 1000 * this.configService.jwtConfig.refreshExpiry
+    const expiresIn = this.configService.jwtConfig.refreshExpiry
     const expiration = ExpiresInToDate(this.configService.jwtConfig.refreshExpiry)
 
     const storedToken = await this.tokenRepository.put({

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -9,6 +9,7 @@ import { LoginRequest, LogoutRequest, RefreshRequest } from '../src/oauth/dto'
 import { RegisterUserRequest } from '../src/user/dto'
 import { UserRole } from '../src/core/database'
 import { AuthorizationTokenType } from '../src/common/const'
+import { jwtConfigDefaults } from '../src/core/config/configs/jwt.config'
 
 describe('E2E authorization', () => {
   let ormSchemaGenerator: SchemaGenerator
@@ -77,6 +78,11 @@ describe('E2E authorization', () => {
 
     expect(refreshTokenResponse.body.access).not.toBe(loginUserResponse.body.access)
     expect(refreshTokenResponse.body.refresh).not.toBe(loginUserResponse.body.refresh)
+
+    const refreshPayload = JSON.parse(
+      Buffer.from(refreshTokenResponse.body.refresh.split('.')[1], 'base64').toString('utf8'),
+    ) as { iat: number; exp: number }
+    expect(refreshPayload.exp - refreshPayload.iat).toBe(jwtConfigDefaults.refreshExpiry)
 
     const revokeTokenResponse = await request(app)
       .post('/api/v1/oauth/revoke')


### PR DESCRIPTION

**Description**:  
Fix refresh token expiration unit mismatch in auth service so JWT refresh token TTL matches configured `JWT_REFRESH_EXPIRY` and persisted token expiry behavior.

* Use configured `refreshExpiry` seconds directly when signing refresh JWT
* Add e2e regression assertion to validate `exp - iat === jwtConfigDefaults.refreshExpiry`
* Keep refresh token DB expiry and JWT claim expiry aligned

**Related issue(s)**:

Fixes #82 

**Notes for reviewer**:

Validation run in `heka-auth-service`:

- `yarn install --frozen-lockfile`
- `yarn test --runInBand --forceExit test/authorization.e2e.test.ts`

Result:

- `PASS test/authorization.e2e.test.ts`
- Added assertion confirms refresh JWT TTL equals configured refresh expiry.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)