### PR TITLE
fix(identity): prevent duplicate notification listeners

### DIFF
--- a/heka-identity-service/src/common/notification/__tests__/notification-events.listener.test.ts
+++ b/heka-identity-service/src/common/notification/__tests__/notification-events.listener.test.ts
@@ -1,0 +1,82 @@
+import { createMock } from '@golevelup/ts-vitest'
+import { EntityManager, MikroORM } from '@mikro-orm/core'
+
+import { Agent } from 'common/agent'
+import { Logger } from 'common/logger'
+
+import { NotificationEventsListener } from '../notification-events.listener'
+import { NotificationService } from '../notification.service'
+
+describe('NotificationEventsListener lifecycle', () => {
+  let agent: Agent
+  let onSpy: ReturnType<typeof vi.fn>
+  let offSpy: ReturnType<typeof vi.fn>
+  let notificationService: NotificationService
+  let orm: MikroORM
+  let em: EntityManager
+  let logger: Logger
+  let warnSpy: ReturnType<typeof vi.fn>
+  let listener: NotificationEventsListener
+
+  beforeEach(() => {
+    onSpy = vi.fn()
+    offSpy = vi.fn()
+    agent = { events: { on: onSpy, off: offSpy } } as unknown as Agent
+    notificationService = createMock<NotificationService>()
+    orm = createMock<MikroORM>()
+    em = createMock<EntityManager>()
+    warnSpy = vi.fn()
+    logger = createMock<Logger>({ warn: warnSpy } as Partial<Logger>)
+
+    listener = new NotificationEventsListener(agent, notificationService, orm, em, logger)
+  })
+
+  test('registers and unregisters exact same handler references', () => {
+    listener.onModuleInit()
+
+    const onCalls = onSpy.mock.calls
+    expect(onCalls.length).toBeGreaterThan(0)
+
+    listener.onModuleDestroy()
+    const offCalls = offSpy.mock.calls
+
+    expect(offCalls.length).toBe(onCalls.length)
+    for (let i = 0; i < onCalls.length; i++) {
+      expect(offCalls[i][0]).toBe(onCalls[i][0])
+      expect(offCalls[i][1]).toBe(onCalls[i][1])
+    }
+  })
+
+  test('does not register duplicate listeners on repeated init', () => {
+    listener.onModuleInit()
+    const firstInitCount = onSpy.mock.calls.length
+
+    listener.onModuleInit()
+    const secondInitCount = onSpy.mock.calls.length
+
+    expect(secondInitCount).toBe(firstInitCount)
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Notification event listeners are already registered, skipping duplicate registration',
+    )
+  })
+
+  test('ignores destroy when listeners were never initialized', () => {
+    listener.onModuleDestroy()
+
+    expect(offSpy).not.toHaveBeenCalled()
+  })
+
+  test('allows re-initialization after destroy', () => {
+    listener.onModuleInit()
+    const firstInitCount = onSpy.mock.calls.length
+
+    listener.onModuleDestroy()
+    const firstDestroyCount = offSpy.mock.calls.length
+
+    listener.onModuleInit()
+    const secondInitCount = onSpy.mock.calls.length
+
+    expect(firstDestroyCount).toBe(firstInitCount)
+    expect(secondInitCount).toBe(firstInitCount * 2)
+  })
+})

--- a/heka-identity-service/src/common/notification/notification-events.listener.ts
+++ b/heka-identity-service/src/common/notification/notification-events.listener.ts
@@ -28,6 +28,9 @@ const NOTIFICATION_EVENT_TYPES: NotificationEventType[] = [
 
 @Injectable()
 export class NotificationEventsListener implements OnModuleInit, OnModuleDestroy {
+  private readonly eventNotificationHandler = this.sendEventNotification.bind(this)
+  private isSubscribed = false
+
   public constructor(
     @Inject(AGENT_TOKEN)
     private readonly agent: Agent,
@@ -43,15 +46,26 @@ export class NotificationEventsListener implements OnModuleInit, OnModuleDestroy
   }
 
   public onModuleInit() {
-    for (const eventType of NOTIFICATION_EVENT_TYPES) {
-      this.agent.events.on(eventType, this.sendEventNotification.bind(this))
+    if (this.isSubscribed) {
+      this.logger.warn('Notification event listeners are already registered, skipping duplicate registration')
+      return
     }
+
+    for (const eventType of NOTIFICATION_EVENT_TYPES) {
+      this.agent.events.on(eventType, this.eventNotificationHandler)
+    }
+    this.isSubscribed = true
   }
 
   public onModuleDestroy() {
-    for (const eventType of NOTIFICATION_EVENT_TYPES) {
-      this.agent.events.off(eventType, this.sendEventNotification.bind(this))
+    if (!this.isSubscribed) {
+      return
     }
+
+    for (const eventType of NOTIFICATION_EVENT_TYPES) {
+      this.agent.events.off(eventType, this.eventNotificationHandler)
+    }
+    this.isSubscribed = false
   }
 
   @UseRequestContext()


### PR DESCRIPTION
**Description**:  
Fix a lifecycle bug in `NotificationEventsListener` where listeners were registered/unregistered with different `bind(this)` function references, causing unsubscribe to fail and enabling duplicate notification dispatch after re-init cycles.

* Use one stable bound handler reference for all event subscriptions
* Register listeners only once via `isSubscribed` guard in `onModuleInit`
* Unsubscribe using the same handler reference in `onModuleDestroy`
* Skip redundant destroy when not subscribed
* Add dedicated unit tests for subscribe/unsubscribe identity and duplicate-init prevention

### Actual issue
In `heka-identity-service/src/common/notification/notification-events.listener.ts`, both lifecycle methods used fresh `this.sendEventNotification.bind(this)` calls:

- `onModuleInit`: `events.on(eventType, this.sendEventNotification.bind(this))`
- `onModuleDestroy`: `events.off(eventType, this.sendEventNotification.bind(this))`

Because each `bind` returns a new function instance, `off(...)` could not remove the original listener.  
This can lead to listener leakage and duplicate notifications/webhook sends after repeated init/destroy cycles.

### What changed
1. Added a stable handler:
   - `private readonly eventNotificationHandler = this.sendEventNotification.bind(this)`
2. Added lifecycle guard:
   - `private isSubscribed = false`
3. Updated module lifecycle logic:
   - `onModuleInit` registers only if not already subscribed
   - `onModuleDestroy` removes listeners with the exact same handler reference
4. Added tests:
   - `heka-identity-service/src/common/notification/__tests__/notification-events.listener.test.ts`

### Verification / tests run
- `npx eslint src/common/notification/notification-events.listener.ts src/common/notification/__tests__/notification-events.listener.test.ts` ✅
- `yarn check-types:src` ✅
- `yarn test:unit src/common/notification/__tests__/notification-events.listener.test.ts` ✅
  - all unit suites passed (including new lifecycle tests)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)