### PR TITLE
fix(security): warn when sensitive env vars fall back to insecure defaults

### DIFF
--- a/heka-auth-service/src/core/config/configs/jwt.config.ts
+++ b/heka-auth-service/src/core/config/configs/jwt.config.ts
@@ -18,6 +18,8 @@ export const jwtConfigDefaults = {
   demoUserTokenExpiry: 60 * 60 * 24 * 365, // ~1 year validity for Demo User
 }
 
+let warnedJwtSecret = false
+
 export class JwtConfig {
   @IsString()
   public issuer!: string
@@ -43,6 +45,26 @@ export class JwtConfig {
     const env = configuration ?? process.env
     this.issuer = env[JwtConfigKeys.issuer] || jwtConfigDefaults.issuer
     this.audience = env[JwtConfigKeys.audience] || jwtConfigDefaults.audience
+
+    // Emit a loud one-time warning if JWT_SECRET is missing and the hardcoded
+    // default 'test' is about to be substituted. This eliminates the silent
+    // fail-open mode reported in issue #17 while preserving the existing
+    // demo-friendly default per maintainer guidance on the issue thread.
+    if (!env[JwtConfigKeys.secret] && !warnedJwtSecret) {
+      warnedJwtSecret = true
+      // eslint-disable-next-line no-console
+      console.warn(
+        [
+          '',
+          '============================================================',
+          `WARNING: ${JwtConfigKeys.secret} is not set; using insecure default for JWT signing secret.`,
+          'This default value is publicly known and MUST NOT be used in production.',
+          `Set the ${JwtConfigKeys.secret} environment variable to override.`,
+          '============================================================',
+          '',
+        ].join('\n'),
+      )
+    }
     this.secret = env[JwtConfigKeys.secret] || jwtConfigDefaults.secret
 
     this.accessExpiry = env[JwtConfigKeys.accessExpiry]

--- a/heka-auth-service/src/core/config/configs/jwt.config.ts
+++ b/heka-auth-service/src/core/config/configs/jwt.config.ts
@@ -46,23 +46,11 @@ export class JwtConfig {
     this.issuer = env[JwtConfigKeys.issuer] || jwtConfigDefaults.issuer
     this.audience = env[JwtConfigKeys.audience] || jwtConfigDefaults.audience
 
-    // Emit a loud one-time warning if JWT_SECRET is missing and the hardcoded
-    // default 'test' is about to be substituted. This eliminates the silent
-    // fail-open mode reported in issue #17 while preserving the existing
-    // demo-friendly default per maintainer guidance on the issue thread.
     if (!env[JwtConfigKeys.secret] && !warnedJwtSecret) {
       warnedJwtSecret = true
       // eslint-disable-next-line no-console
       console.warn(
-        [
-          '',
-          '============================================================',
-          `WARNING: ${JwtConfigKeys.secret} is not set; using insecure default for JWT signing secret.`,
-          'This default value is publicly known and MUST NOT be used in production.',
-          `Set the ${JwtConfigKeys.secret} environment variable to override.`,
-          '============================================================',
-          '',
-        ].join('\n'),
+        `WARNING: ${JwtConfigKeys.secret} not set; using insecure default for JWT signing secret. Do not use in production.`,
       )
     }
     this.secret = env[JwtConfigKeys.secret] || jwtConfigDefaults.secret

--- a/heka-identity-service/src/config/agent.ts
+++ b/heka-identity-service/src/config/agent.ts
@@ -11,6 +11,7 @@ import express from 'express'
 import { AriesCredentialFormat, ProtocolType } from 'common/types'
 
 import { CredentialsConfiguration } from './credential-configuration'
+import { valueOrDefaultWithWarning } from './secret-default-warning'
 
 export default registerAs('agent', () => {
   const label = process.env.AGENT_LABEL ?? 'Heka'
@@ -58,7 +59,11 @@ export default registerAs('agent', () => {
   const walletPostgresHost = process.env.WALLET_POSTGRES_HOST ?? 'localhost'
   const walletPostgresPort = process.env.WALLET_POSTGRES_PORT ? parseInt(process.env.WALLET_POSTGRES_PORT, 10) : 5432
   const walletPostgresUser = process.env.WALLET_POSTGRES_USER ?? 'heka'
-  const walletPostgresPass = process.env.WALLET_POSTGRES_PASSWORD ?? 'heka1'
+  const walletPostgresPass = valueOrDefaultWithWarning(
+    'WALLET_POSTGRES_PASSWORD',
+    'heka1',
+    'Aries wallet database password',
+  )
 
   const host = process.env.EXPRESS_HOST || 'localhost'
   const httpEndpoint = process.env.AGENT_HTTP_ENDPOINT ?? `http://${host}:${httpPort}`
@@ -68,23 +73,32 @@ export default registerAs('agent', () => {
   // FIXME: Add `indybesu` DID method once we get public network deployed
   const didMethods = process.env.DID_METHODS ? process.env.DID_METHODS.split(',') : ['indy', 'key', 'hedera']
 
-  const indyEndorserSeed = process.env.INDY_ENDORSER_SEED ?? 'afjdemoverysecure000000000000002'
+  const indyEndorserSeed = valueOrDefaultWithWarning(
+    'INDY_ENDORSER_SEED',
+    'afjdemoverysecure000000000000002',
+    'Indy DID endorser seed (deterministically derives the on-ledger write key)',
+  )
   //const indyEndorserId = process.env.INDY_ENDORSER_ID ?? ''
   const indyEndorserDid = process.env.INDY_ENDORSER_DID ?? 'did:indy:bcovrin:test:4bbYgjU6JbV4DShPbGoQcA'
 
   const indyBesuChainId = process.env.INDY_BESU_CHAIN_ID ? parseInt(process.env.INDY_BESU_CHAIN_ID) : 1337
   const indyBesuNodeAddress = process.env.INDY_BESU_NODE_ADDRESS ?? 'http://localhost:8545'
   const indyBesuNetwork = process.env.INDY_BESU_NETWORK ?? 'testnet'
-  const indyBesuEndorserPrivateKey =
-    process.env.INDY_BESU_ENDORSER_PRIVATE_KEY ?? 'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3'
+  const indyBesuEndorserPrivateKey = valueOrDefaultWithWarning(
+    'INDY_BESU_ENDORSER_PRIVATE_KEY',
+    'c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3',
+    'Indy-Besu endorser ECDSA private key',
+  )
   const indyBesuEndorserPublicKey =
     process.env.INDY_BESU_ENDORSER_PUBLIC_KEY ?? '03af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d'
 
   const hederaNetwork: HederaNetwork = (process.env.HEDERA_NETWORK as HederaNetwork) ?? 'testnet'
   const hederaOperatorId = process.env.HEDERA_OPERATOR_ID ?? '0.0.5489553'
-  const hederaOperatorKey =
-    process.env.HEDERA_OPERATOR_KEY ??
-    '302e020100300506032b6570042204209f54b75b6238ced43e41b1463999cb40bf2f7dd2c9fd4fd3ef780027c016a138'
+  const hederaOperatorKey = valueOrDefaultWithWarning(
+    'HEDERA_OPERATOR_KEY',
+    '302e020100300506032b6570042204209f54b75b6238ced43e41b1463999cb40bf2f7dd2c9fd4fd3ef780027c016a138',
+    'Hedera operator private key',
+  )
 
   const oidConfig = {
     port: oid4VcPort,
@@ -119,9 +133,12 @@ export default registerAs('agent', () => {
   }
 
   const mdlIssuerCertificate = process.env.MDL_ISSUER_CERTIFICATE ?? 'MIIBwDCCAWWgAwIBAgIUSMdjaVc1KHI+3o6qJXhSC4sJh+cwCgYIKoZIzj0EAwIwNTEXMBUGA1UEAwwObURMIElzc3VlciBEZXYxDTALBgNVBAoMBEhla2ExCzAJBgNVBAYTAlVTMB4XDTI2MDMyNzIxNDA1NloXDTM2MDMyNDIxNDA1NlowNTEXMBUGA1UEAwwObURMIElzc3VlciBEZXYxDTALBgNVBAoMBEhla2ExCzAJBgNVBAYTAlVTMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1nIrm3O9VX8MdPrKWMhqqV0QMS4UtxKj6uUc8IdGE2fSsWyi7XQN3HoE1Ln9TDtOIHvSyW8Eyr98MlWGBBF/vqNTMFEwHQYDVR0OBBYEFNfkrHxd2nwtni96XrrYhaMgUFImMB8GA1UdIwQYMBaAFNfkrHxd2nwtni96XrrYhaMgUFImMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAP0V5EW7j6Pb+lJktzdWrtEqhI3mYs9Fd+qh0p2kNXJPAiEAqK+q7Wk+t5e2yzvO3b6t3P5nIEnoQt3cvDsaUZY1dT0='
-  const mdlIssuerPrivateKeyJwk = process.env.MDL_ISSUER_PRIVATE_KEY
-    ? (JSON.parse(process.env.MDL_ISSUER_PRIVATE_KEY) as Record<string, string>)
-    : (JSON.parse('{"kty":"EC","x":"1nIrm3O9VX8MdPrKWMhqqV0QMS4UtxKj6uUc8IdGE2c","y":"0rFsou10Ddx6BNS5_Uw7TiB70slvBMq_fDJVhgQRf74","crv":"P-256","d":"ioXmEeGGMTLWF8AZwFwufaR5e_oGTfxR2IrZSQ9niLA","kid":"4f138202-31fb-4f13-b779-8f61b2bef253"}') as Record<string, string>)
+  const mdlIssuerPrivateKeyJwkRaw = valueOrDefaultWithWarning(
+    'MDL_ISSUER_PRIVATE_KEY',
+    '{"kty":"EC","x":"1nIrm3O9VX8MdPrKWMhqqV0QMS4UtxKj6uUc8IdGE2c","y":"0rFsou10Ddx6BNS5_Uw7TiB70slvBMq_fDJVhgQRf74","crv":"P-256","d":"ioXmEeGGMTLWF8AZwFwufaR5e_oGTfxR2IrZSQ9niLA","kid":"4f138202-31fb-4f13-b779-8f61b2bef253"}',
+    'mDL issuer private JWK',
+  )
+  const mdlIssuerPrivateKeyJwk = JSON.parse(mdlIssuerPrivateKeyJwkRaw) as Record<string, string>
 
   const credentialsConfiguration: CredentialsConfiguration = {
     [ProtocolType.Oid4vc]: {

--- a/heka-identity-service/src/config/jwt.ts
+++ b/heka-identity-service/src/config/jwt.ts
@@ -1,10 +1,12 @@
 import { registerAs } from '@nestjs/config'
 import { JwtModuleOptions } from '@nestjs/jwt'
 
+import { valueOrDefaultWithWarning } from './secret-default-warning'
+
 export default registerAs(
   'jwt',
   (): JwtModuleOptions => ({
-    secret: process.env.JWT_SECRET || 'test',
+    secret: valueOrDefaultWithWarning('JWT_SECRET', 'test', 'JWT signing secret'),
     verifyOptions: {
       issuer: process.env.JWT_VERIFY_OPTIONS_ISSUER || 'Heka',
       audience: process.env.JWT_VERIFY_OPTIONS_AUDIENCE || 'Heka Identity Service',

--- a/heka-identity-service/src/config/mikro-orm.ts
+++ b/heka-identity-service/src/config/mikro-orm.ts
@@ -1,11 +1,13 @@
 import { registerAs } from '@nestjs/config'
 
+import { valueOrDefaultWithWarning } from './secret-default-warning'
+
 export default registerAs('mikro-orm', () => ({
   type: process.env.MIKRO_ORM_DATABASE_TYPE || 'postgresql',
   host: process.env.MIKRO_ORM_HOST || 'localhost',
   port: process.env.MIKRO_ORM_PORT ? parseInt(process.env.MIKRO_ORM_PORT, 10) : 5432,
   user: process.env.MIKRO_ORM_USER || 'heka',
-  password: process.env.MIKRO_ORM_PASSWORD || 'heka1',
+  password: valueOrDefaultWithWarning('MIKRO_ORM_PASSWORD', 'heka1', 'identity-service database password'),
   dbName: process.env.MIKRO_ORM_DATABASE || 'heka-identity-service',
   logging: process.env.MIKRO_ORM_LOGGING || 'all',
   driverOptions: {

--- a/heka-identity-service/src/config/secret-default-warning.ts
+++ b/heka-identity-service/src/config/secret-default-warning.ts
@@ -1,22 +1,5 @@
-/**
- * Returns the value of the named environment variable if it is set (non-empty),
- * otherwise emits a one-time loud warning to stderr and returns the supplied fallback.
- *
- * Why this exists:
- *   Several `registerAs(...)` config factories in this service used to silently fall
- *   back to hardcoded, publicly-known development credentials whenever the operator
- *   forgot to set the corresponding env var. The fallback was indistinguishable from
- *   an explicit configuration choice, which let services boot successfully in a
- *   completely insecure state (see GitHub issue #17).
- *
- * Why `console.warn` (not the Nest/Pino logger):
- *   `registerAs` factories run during module construction, BEFORE the Pino logger
- *   has been instantiated. The warning has to be emitted via `console` so it is
- *   visible regardless of logger init order.
- *
- * The warning is emitted at most once per `envName` per process so that callers
- * who read the same env var multiple times do not spam the log.
- */
+// Uses console.warn (not the Nest/Pino logger) because registerAs() factories
+// run before the logger is initialised.
 const warnedFor = new Set<string>()
 
 export function valueOrDefaultWithWarning(envName: string, fallback: string, label: string): string {
@@ -28,17 +11,7 @@ export function valueOrDefaultWithWarning(envName: string, fallback: string, lab
   if (!warnedFor.has(envName)) {
     warnedFor.add(envName)
     // eslint-disable-next-line no-console
-    console.warn(
-      [
-        '',
-        '============================================================',
-        `WARNING: ${envName} is not set; using insecure default for ${label}.`,
-        'This default value is publicly known and MUST NOT be used in production.',
-        `Set the ${envName} environment variable to override.`,
-        '============================================================',
-        '',
-      ].join('\n'),
-    )
+    console.warn(`WARNING: ${envName} not set; using insecure default for ${label}. Do not use in production.`)
   }
 
   return fallback

--- a/heka-identity-service/src/config/secret-default-warning.ts
+++ b/heka-identity-service/src/config/secret-default-warning.ts
@@ -1,0 +1,45 @@
+/**
+ * Returns the value of the named environment variable if it is set (non-empty),
+ * otherwise emits a one-time loud warning to stderr and returns the supplied fallback.
+ *
+ * Why this exists:
+ *   Several `registerAs(...)` config factories in this service used to silently fall
+ *   back to hardcoded, publicly-known development credentials whenever the operator
+ *   forgot to set the corresponding env var. The fallback was indistinguishable from
+ *   an explicit configuration choice, which let services boot successfully in a
+ *   completely insecure state (see GitHub issue #17).
+ *
+ * Why `console.warn` (not the Nest/Pino logger):
+ *   `registerAs` factories run during module construction, BEFORE the Pino logger
+ *   has been instantiated. The warning has to be emitted via `console` so it is
+ *   visible regardless of logger init order.
+ *
+ * The warning is emitted at most once per `envName` per process so that callers
+ * who read the same env var multiple times do not spam the log.
+ */
+const warnedFor = new Set<string>()
+
+export function valueOrDefaultWithWarning(envName: string, fallback: string, label: string): string {
+  const raw = process.env[envName]
+  if (raw && raw.length > 0) {
+    return raw
+  }
+
+  if (!warnedFor.has(envName)) {
+    warnedFor.add(envName)
+    // eslint-disable-next-line no-console
+    console.warn(
+      [
+        '',
+        '============================================================',
+        `WARNING: ${envName} is not set; using insecure default for ${label}.`,
+        'This default value is publicly known and MUST NOT be used in production.',
+        `Set the ${envName} environment variable to override.`,
+        '============================================================',
+        '',
+      ].join('\n'),
+    )
+  }
+
+  return fallback
+}


### PR DESCRIPTION
closes #17

## why

missing env vars silently activate hardcoded fallback secrets in 7 places: jwt secret (both services), db passwords, indy seed, indy-besu key, hedera key, mdl jwk. all defaults are publicly-known constants checked into the repo.

## what

route the 7 fall-backs through a one-time warn-on-default helper.

## where

- heka-auth-service: `src/core/config/configs/jwt.config.ts`
- heka-identity-service: `src/config/{jwt,mikro-orm,agent}.ts`
- new helper: `heka-identity-service/src/config/secret-default-warning.ts`