### PR TITLE
feat(ci): enforce undeclared dependency detection via ESLint

### DIFF
--- a/heka-identity-service/.eslintrc.js
+++ b/heka-identity-service/.eslintrc.js
@@ -46,6 +46,22 @@ module.exports = {
         },
       },
     ],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          '**/*.test.ts',
+          '**/*.spec.ts',
+          '**/__tests__/**/*',
+          '**/__mocks__/**/*',
+          'test/**/*',
+          'vitest.config.mts',
+          '.eslintrc.js',
+        ],
+        peerDependencies: false,
+        optionalDependencies: false,
+      },
+    ],
   },
   overrides: [
     {

--- a/heka-identity-service/package.json
+++ b/heka-identity-service/package.json
@@ -71,7 +71,7 @@
     "class-validator": "^0.14.0",
     "colorette": "^2.0.20",
     "ethers": "^6.8.1",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "express-promise-router": "^4.1.1",
     "fs-extra": "^11.1.1",
     "indybesu-vdr": "file:indy-besu-vdr-pkg",

--- a/heka-identity-service/package.json
+++ b/heka-identity-service/package.json
@@ -39,6 +39,7 @@
     "@credo-ts/openid4vc": "0.6.2",
     "@credo-ts/tenants": "0.6.2",
     "@digitalcredentials/bitstring": "^3.1.2",
+    "@hiero-did-sdk/client": "^0.1.8",
     "@hyperledger/anoncreds-nodejs": "^0.3.4",
     "@hyperledger/anoncreds-shared": "^0.3.4",
     "@hyperledger/indy-vdr-nodejs": "^0.2.3",
@@ -65,10 +66,12 @@
     "@types/multer": "^1.4.11",
     "async-mutex": "^0.5.0",
     "axios": "^1.6.0",
+    "chalk": "^4.1.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "colorette": "^2.0.20",
     "ethers": "^6.8.1",
+    "express": "^5.1.0",
     "express-promise-router": "^4.1.1",
     "fs-extra": "^11.1.1",
     "indybesu-vdr": "file:indy-besu-vdr-pkg",
@@ -86,7 +89,9 @@
     "swagger-ui-express": "^4.6.2",
     "typescript": "~5.5.2",
     "uuid": "^9.0.0",
+    "ws": "^8.13.0",
     "yaml": "^2.2.2",
+    "zod": "^4.3.6",
     "zstd-napi": "^0.0.10"
   },
   "devDependencies": {
@@ -102,6 +107,7 @@
     "@types/passport-jwt": "^3.0.8",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.1",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "did-resolver": "^4.1.0",
@@ -122,8 +128,7 @@
     "tsconfig-paths": "^4.2.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.8",
-    "vitest-when": "0.5.0",
-    "ws": "^8.13.0"
+    "vitest-when": "0.5.0"
   },
   "mikro-orm": {
     "useTsNode": true

--- a/heka-identity-service/yarn.lock
+++ b/heka-identity-service/yarn.lock
@@ -5909,7 +5909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^5.1.0, express@npm:^5.2.1":
+"express@npm:^5.2.1":
   version: 5.2.1
   resolution: "express@npm:5.2.1"
   dependencies:
@@ -6769,7 +6769,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.27.5"
     eslint-plugin-prettier: "npm:^5.1.3"
     ethers: "npm:^6.8.1"
-    express: "npm:^5.1.0"
+    express: "npm:^5.2.1"
     express-promise-router: "npm:^4.1.1"
     fs-extra: "npm:^11.1.1"
     indybesu-vdr: "file:indy-besu-vdr-pkg"

--- a/heka-identity-service/yarn.lock
+++ b/heka-identity-service/yarn.lock
@@ -5909,7 +5909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^5.2.1":
+"express@npm:^5.1.0, express@npm:^5.2.1":
   version: 5.2.1
   resolution: "express@npm:5.2.1"
   dependencies:
@@ -6718,6 +6718,7 @@ __metadata:
     "@credo-ts/tenants": "npm:0.6.2"
     "@digitalcredentials/bitstring": "npm:^3.1.2"
     "@golevelup/ts-vitest": "npm:^0.5.2"
+    "@hiero-did-sdk/client": "npm:^0.1.8"
     "@hyperledger/anoncreds-nodejs": "npm:^0.3.4"
     "@hyperledger/anoncreds-shared": "npm:^0.3.4"
     "@hyperledger/indy-vdr-nodejs": "npm:^0.2.3"
@@ -6752,10 +6753,12 @@ __metadata:
     "@types/passport-jwt": "npm:^3.0.8"
     "@types/supertest": "npm:^2.0.12"
     "@types/uuid": "npm:^9.0.1"
+    "@types/ws": "npm:^8.18.1"
     "@typescript-eslint/eslint-plugin": "npm:^5.59.8"
     "@typescript-eslint/parser": "npm:^5.59.8"
     async-mutex: "npm:^0.5.0"
     axios: "npm:^1.6.0"
+    chalk: "npm:^4.1.2"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.0"
     colorette: "npm:^2.0.20"
@@ -6766,6 +6769,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.27.5"
     eslint-plugin-prettier: "npm:^5.1.3"
     ethers: "npm:^6.8.1"
+    express: "npm:^5.1.0"
     express-promise-router: "npm:^4.1.1"
     fs-extra: "npm:^11.1.1"
     indybesu-vdr: "file:indy-besu-vdr-pkg"
@@ -6798,6 +6802,7 @@ __metadata:
     vitest-when: "npm:0.5.0"
     ws: "npm:^8.13.0"
     yaml: "npm:^2.2.2"
+    zod: "npm:^4.3.6"
     zstd-napi: "npm:^0.0.10"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Closes #81

## Background

In #72, the build failure exposed a **phantom dependency** issue — `zod` was imported in source code but not declared in `package.json`. Due to `nodeLinker: node-modules`, the import resolved locally via hoisted transitive dependencies (from `nestjs-zod`), but this class of issue is not reliably caught by `yarn install --immutable`.

This means a package can be used in runtime code without being explicitly declared, leading to fragile builds that depend on the shape of the dependency tree.

---

## Problem

The current setup enforces **lockfile consistency**, but does not enforce **correct dependency declaration**.

As a result:
- Undeclared dependencies can silently work in development
- Failures only surface when the dependency tree changes
- There is no feedback loop during development or CI to catch this early

---

## Solution

This PR enforces correct dependency usage by enabling:

### `import/no-extraneous-dependencies` (ESLint)

- Validates every `import` against `package.json`
- Ensures all runtime imports come from declared `dependencies`
- Allows `devDependencies` only in test and configuration files

This rule is implemented using existing tooling:
- `eslint-plugin-import` (already installed)
- `eslint-import-resolver-typescript` (handles `baseUrl: "src"` path aliases)

No additional dependencies or CI steps are introduced — the check runs as part of the existing `yarn lint` workflow.

---

## Additional Fixes

While enabling the rule, it surfaced several existing issues in the codebase:

| Package | Issue |
|--------|------|
| `chalk` | Used in runtime code but not declared |
| `@hiero-did-sdk/client` | Imported but not declared (transitive dependency) |
| `express` | Imported directly but not declared |
| `ws` | Declared as `devDependency` but used in runtime code |
| `@types/ws` | Missing type definition |

These have been corrected in this PR to ensure full compliance.

---

## Changes

- `.eslintrc.js`
  - Added `import/no-extraneous-dependencies` as an `error` rule
  - Configured allowed usage of `devDependencies` in test/config files

- `package.json`
  - Added missing runtime dependencies
  - Corrected dependency classifications
  - Added missing type definitions

- `yarn.lock`
  - Synced with updated dependency declarations

---

## Result

- Prevents phantom dependency issues like the one in #72
- Enforces explicit dependency declaration
- Provides immediate feedback during development and CI
- Improves long-term build reliability

---

## Verification

- `yarn install --immutable` passes  
- `yarn lint` reports zero errors  
- No false positives with TypeScript path aliases (`baseUrl: "src"`)  
- No false positives in test files using `devDependencies`  

---

## Notes

This complements #72 by addressing a different failure class:

- #72 → fixes a specific build failure  
- #81 (this PR) → prevents similar issues from occurring in the future  

---