### PR TITLE
perf(db): add missing @Index decorators to tenantId and publicDid in wallet.entity.ts

### DIFF
--- a/heka-identity-service/migrations/Migration20260430201419.ts
+++ b/heka-identity-service/migrations/Migration20260430201419.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260430201419 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('create index "wallet_tenant_id_index" on "wallet" ("tenant_id");');
+    this.addSql('create index "wallet_public_did_index" on "wallet" ("public_did");');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop index "wallet_tenant_id_index";');
+    this.addSql('drop index "wallet_public_did_index";');
+  }
+
+}

--- a/heka-identity-service/src/common/entities/wallet.entity.ts
+++ b/heka-identity-service/src/common/entities/wallet.entity.ts
@@ -1,13 +1,15 @@
-import { Collection, Entity, ManyToMany, Property } from '@mikro-orm/core'
+import { Collection, Entity, Index, ManyToMany, Property } from '@mikro-orm/core'
 
 import { Identified } from './identified.entity'
 import { User } from './user.entity'
 
 @Entity()
 export class Wallet extends Identified {
+  @Index()
   @Property()
   public tenantId: string
 
+  @Index()
   @Property({ nullable: true })
   public publicDid?: string
 


### PR DESCRIPTION
## Summary
Adds missing `@Index()` decorators to the `tenantId` and `publicDid` 
fields in `wallet.entity.ts` and generates the corresponding migration.

## Problem
`tenantId` and `publicDid` are used to scope almost every query in 
the system. Without `@Index()` decorators, PostgreSQL performs a full 
table scan on every wallet lookup — this will cause severe performance 
degradation as the platform scales with more contributors and tenants.

## Changes
- Added `@Index()` to `tenantId` field in `wallet.entity.ts`
- Added `@Index()` to `publicDid` field in `wallet.entity.ts`  
- Generated MikroORM migration: `Migration20260430201419_add-wallet-indexes.ts`

## Impact
- Wallet lookups by tenant become O(log n) instead of O(n)
- No breaking changes — indexes are purely additive
- Runtime logic completely unchanged

## Testing
- `lint:ts` passes with 0 errors
- Migration generated and verified