### PR TITLE
fix(auth): ensure BearerGuard and UserAuthGuard return boolean

### DIFF
--- a/heka-auth-service/src/oauth/guards/bearer.guard.ts
+++ b/heka-auth-service/src/oauth/guards/bearer.guard.ts
@@ -4,11 +4,11 @@ import { IncomingMessage } from 'http'
 
 @Injectable()
 export class BearerGuard implements CanActivate {
-  public canActivate(context: ExecutionContext): Promise<boolean> {
+  public async canActivate(context: ExecutionContext): Promise<boolean> {
     try {
       const request = context.switchToHttp().getRequest()
       request['accessToken'] = extractTokenFromRequest(request)
-      return request
+      return true
     } catch {
       throw new UnauthorizedException()
     }

--- a/heka-auth-service/src/oauth/guards/user.guard.ts
+++ b/heka-auth-service/src/oauth/guards/user.guard.ts
@@ -28,7 +28,7 @@ export class UserAuthGuard extends AuthGuard('jwt') {
       if (!user) throw new UnauthorizedException()
 
       request['sender'] = user
-      return request
+      return true
     } catch {
       throw new UnauthorizedException()
     }


### PR DESCRIPTION
**Description**:

Fix BearerGuard and UserAuthGuard return types to strictly adhere to the NestJS CanActivate contract. Previously, these guards returned the raw request object instead of a boolean, which was type-unsafe and violated framework expectations.
- Update BearerGuard.canActivate to be async and explicitly return true.
- Update UserAuthGuard.canActivate to return true instead of the request object.
- Preserve the logic for attaching accessToken and sender metadata to the request object.

**Related issue(s)**:

Fixes #95 

**Notes for reviewer**:
The previous implementation worked due to JavaScript's truthiness (since an object is truthy), but it broke the TypeScript contract of the CanActivate interface. These changes ensure the guards are type-safe and compatible with future NestJS updates. Unit tests have been run to verify that true is returned and metadata is correctly attached.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
