### PR TITLE
fix(identity-service): prevent out-of-bounds status list indexes

### DIFF
--- a/heka-identity-service/src/revocation/status-list/__tests__/status-list.service.test.ts
+++ b/heka-identity-service/src/revocation/status-list/__tests__/status-list.service.test.ts
@@ -246,6 +246,23 @@ describe('StatusListService', () => {
       await expect(service.addItems(authInfo, 'bad-id', [0])).rejects.toThrow('Entity not found')
       expect(em.findOneOrFail).toHaveBeenCalledWith(CredentialStatusList, { id: 'bad-id', owner: mockUser })
     })
+
+    test('should throw BadRequestException when there are not enough free indexes', async () => {
+      const id = 'status-list-1'
+      const statusListEntity = entityStub<CredentialStatusList>({
+        id,
+        encodedList: 'original-encoded',
+        lastIndex: 99,
+        size: 100,
+        owner: mockUser,
+      })
+
+      vi.mocked(em.findOneOrFail).mockResolvedValue(statusListEntity)
+
+      await expect(service.addItems(authInfo, id, [100, 101])).rejects.toThrow(BadRequestException)
+      expect(mockSet).not.toHaveBeenCalled()
+      expect(em.flush).not.toHaveBeenCalled()
+    })
   })
 
   describe('updateItems', () => {
@@ -303,10 +320,8 @@ describe('StatusListService', () => {
 
       vi.mocked(em.findOneOrFail).mockResolvedValue(statusListEntity)
 
-      // decodeBits returns a buffer of length 100, so index 200 is out of bounds
-      // The service checks `index > decodedList.length`
-      // Buffer.alloc(100) has length 100, so index 200 > 100
-      await expect(service.updateItems(authInfo, id, { indexes: [200], revoked: true })).rejects.toThrow(
+      // decodeBits returns a buffer of length 100, so index 100 is out of bounds
+      await expect(service.updateItems(authInfo, id, { indexes: [100], revoked: true })).rejects.toThrow(
         BadRequestException,
       )
     })

--- a/heka-identity-service/src/revocation/status-list/status-list.service.ts
+++ b/heka-identity-service/src/revocation/status-list/status-list.service.ts
@@ -83,6 +83,10 @@ export class StatusListService {
   public async addItems(authInfo: AuthInfo, id: string, indexes: Array<number>): Promise<void> {
     const statusList = await this.em.findOneOrFail(CredentialStatusList, { id, owner: authInfo.user })
 
+    if (statusList.lastIndex + indexes.length > statusList.size) {
+      throw new BadRequestException('Status list does not have enough free indexes')
+    }
+
     statusList.encodedList = await this.updatedBistring(statusList.encodedList, indexes, false)
     statusList.lastIndex = statusList.lastIndex += indexes.length
 
@@ -122,7 +126,7 @@ export class StatusListService {
 
     // set items
     for (const index of indexes) {
-      if (index > decodedList.length) {
+      if (index < 0 || index >= decodedList.length) {
         throw new BadRequestException('Status list index is out of bounds')
       }
       bitstring.set(index, revoked)


### PR DESCRIPTION
**Description**:

Prevent invalid credential status indexes from being written to revocation status lists.

  - Reject status list updates when a requested index is outside the decoded bitstring bounds
  - Reject batch additions when the list does not have enough free indexes
  - Add unit coverage for full-list and boundary-index cases

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

  Validation run locally:
  
    cd heka-identity-service
    yarn test:unit src/revocation/status-list/__tests__/status-list.service.test.ts
    yarn check-types:src
    git diff --check
    
    yarn lint-check was also run, but the repository currently reports existing unrelated lint issues outside this change.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
