### PR TITLE
fix(auth): validate refresh token ownership on logout

### DIFF
--- a/heka-auth-service/src/oauth/guards/user.guard.ts
+++ b/heka-auth-service/src/oauth/guards/user.guard.ts
@@ -19,6 +19,8 @@ export class UserAuthGuard extends AuthGuard('jwt') {
       const request = context.switchToHttp().getRequest()
 
       const token = extractTokenFromRequest(request)
+      request['accessToken'] = token
+
       const storedToken = await this.tokenRepository.get(token)
       if (!storedToken) throw new UnauthorizedException()
 

--- a/heka-auth-service/src/oauth/oauth.controller.ts
+++ b/heka-auth-service/src/oauth/oauth.controller.ts
@@ -36,10 +36,10 @@ export class OAuthController {
   @ApiBearerAuth()
   @HttpCode(HttpStatus.RESET_CONTENT)
   @Post('revoke')
-  public async logout(@Body() body: LogoutRequest): Promise<void> {
+  public async logout(@AccessToken() accessToken: string, @Body() body: LogoutRequest): Promise<void> {
     this.logger.verbose('logout >')
 
-    await this.authService.logout(body)
+    await this.authService.logout(accessToken, body)
 
     this.logger.verbose('logout <')
   }

--- a/heka-auth-service/src/oauth/oauth.service.ts
+++ b/heka-auth-service/src/oauth/oauth.service.ts
@@ -95,19 +95,22 @@ export class OAuthService {
     return await this.generateTokens(user)
   }
 
-  public async logout(data: LogoutRequest): Promise<void> {
+  public async logout(accessToken: string, data: LogoutRequest): Promise<void> {
     // resolve access token by refresh token
     const storedRefreshToken = await this.tokenRepository.get(data.refresh)
     if (!storedRefreshToken || !storedRefreshToken.payload) {
       return
     }
 
+    const tokenPayload = classFromJson(storedRefreshToken.payload, AccessTokenPayload).accessToken
+    if (accessToken !== tokenPayload) {
+      throw new UnauthorizedException('Refresh token is incorrect.')
+    }
+
     const user = await this.userRepository.findOne({ id: storedRefreshToken.subject })
     if (!user) {
       return
     }
-
-    const accessToken = classFromJson(storedRefreshToken.payload, AccessTokenPayload).accessToken
 
     // skip token invalidation for demo user
     if (user.isDemoUser(this.configService.jwtConfig)) {

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -31,8 +31,9 @@ describe('E2E authorization', () => {
     await ormSchemaGenerator.clearDatabase()
   })
 
+  let userCounter = 0
   const newUser = () => ({
-    name: 'user' + Date.now().toString(),
+    name: `user${Date.now().toString()}-${userCounter++}`,
     password: 'Password1234!',
   })
 
@@ -108,6 +109,61 @@ describe('E2E authorization', () => {
       } satisfies LoginRequest)
 
     expect(loginUserResponse.status).toBe(401)
+  })
+
+  test('logout rejects refresh token that belongs to another access token', async () => {
+    const firstUser = newUser()
+    const secondUser = newUser()
+
+    await request(app)
+      .post('/api/v1/user/register')
+      .send({
+        name: firstUser.name,
+        password: firstUser.password,
+        role: UserRole.Issuer,
+      } satisfies RegisterUserRequest)
+      .expect(201)
+
+    await request(app)
+      .post('/api/v1/user/register')
+      .send({
+        name: secondUser.name,
+        password: secondUser.password,
+        role: UserRole.Issuer,
+      } satisfies RegisterUserRequest)
+      .expect(201)
+
+    const firstLoginResponse = await request(app)
+      .post('/api/v1/oauth/token')
+      .send({
+        name: firstUser.name,
+        password: firstUser.password,
+      } satisfies LoginRequest)
+      .expect(200)
+
+    const secondLoginResponse = await request(app)
+      .post('/api/v1/oauth/token')
+      .send({
+        name: secondUser.name,
+        password: secondUser.password,
+      } satisfies LoginRequest)
+      .expect(200)
+
+    await request(app)
+      .post('/api/v1/oauth/revoke')
+      .auth(firstLoginResponse.body.access, { type: 'bearer' })
+      .send({
+        refresh: secondLoginResponse.body.refresh,
+      } satisfies LogoutRequest)
+      .expect(401)
+
+    await request(app)
+      .post('/api/v1/oauth/refresh')
+      .auth(secondLoginResponse.body.access, { type: 'bearer' })
+      .send({
+        refresh: secondLoginResponse.body.refresh,
+      } satisfies RefreshRequest)
+      .expect(200)
   })
 
   test('profile endpoint requires authentication', async () => {


### PR DESCRIPTION

  **Description**:

  ## Problem
  The logout (`/oauth/revoke`) endpoint revokes refresh tokens without verifying that the submitted refresh token belongs to the
  authenticated access token.

  This allows one authenticated session to revoke another session if it obtains that session's refresh token, causing a session
  integrity issue.

  ## Fix
  Prevent logout requests from revoking a refresh token that does not belong to the authenticated access token.

  * Store the bearer access token on the request after authentication
  * Pass the authenticated access token into the logout service flow
  * Verify that the submitted refresh token is paired with the authenticated access token before revocation
  * Return `401 Unauthorized` when the refresh token belongs to a different access token
  * Add an e2e test covering cross-user refresh token misuse during logout

  ## Security Impact
  Prevents unauthorized session revocation across access/refresh token pairs.

  **Related issue(s)**:

  Fixes #

  **Notes for reviewer**:

  Local verification was run in `heka-auth-service` with Node `v20.20.2`.

  ```bash
  yarn check-types
  yarn lint-check
  yarn test
  ```

  Result:

  ```text
  Test Suites: 1 passed, 1 total
  Tests:       4 passed, 4 total
  ```

  **Checklist**

  - [x] Documented (Code comments, README, etc.)
  - [x] Tested (unit, integration, etc.)