### PR TITLE
fix: prevent crash when Authorization header is missing

### DIFF
--- a/heka-auth-service/src/oauth/guards/bearer.guard.ts
+++ b/heka-auth-service/src/oauth/guards/bearer.guard.ts
@@ -17,7 +17,10 @@ export class BearerGuard implements CanActivate {
 
 export function extractTokenFromRequest(request: IncomingMessage): string {
   const [type, token] = request.headers[AuthorizationHeader]?.split(' ') ?? []
-  if (type.toLowerCase() !== AuthorizationTokenType.toLowerCase()) {
+  if (!type || type.toLowerCase() !== AuthorizationTokenType.toLowerCase()) {
+    throw new UnauthorizedException()
+  }
+  if (!token) {
     throw new UnauthorizedException()
   }
   return token


### PR DESCRIPTION
**Description**:

Fix crash in BearerGuard when Authorization header is missing.

* Add guard check to ensure `type` exists before calling `toLowerCase()`
* Add guard check to ensure `token` is present before returning
* Ensure function throws `UnauthorizedException` instead of crashing

**Related issue(s)**:

Fixes #111 

**Notes for reviewer**:

This is a minimal, localized fix in the token extraction logic. It prevents a runtime error when the Authorization header is missing or malformed, ensuring consistent 401 Unauthorized responses without affecting existing behavior.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
