### PR TITLE
fix: persist publicDid to wallet after DID creation

### DIFF
--- a/heka-identity-service/src/did/__tests__/did.service.test.ts
+++ b/heka-identity-service/src/did/__tests__/did.service.test.ts
@@ -187,7 +187,7 @@ describe('DidService', () => {
         namespace: 'test-ns',
       })
       expect(em.flush).toHaveBeenCalled()
-      expect(wallet.publicDid).toBe('did:indy:test-ns:newdid') 
+      expect(wallet.publicDid).toBe('did:indy:test-ns:newdid')
     })
     test('throws when create is called twice for the same wallet', async () => {
       const wallet = { id: 'wallet-1', publicDid: null }

--- a/heka-identity-service/src/did/__tests__/did.service.test.ts
+++ b/heka-identity-service/src/did/__tests__/did.service.test.ts
@@ -167,7 +167,8 @@ describe('DidService', () => {
     })
 
     test('creates DID via didRegistrarService when no controller wallet is required (Admin role)', async () => {
-      vi.mocked(em.findOneOrFail).mockResolvedValue({ id: 'wallet-1', publicDid: null })
+      const wallet = { id: 'wallet-1', publicDid: null }
+      vi.mocked(em.findOneOrFail).mockResolvedValue(wallet)
 
       const didDocument = {
         id: 'did:indy:test-ns:newdid',
@@ -186,6 +187,22 @@ describe('DidService', () => {
         namespace: 'test-ns',
       })
       expect(em.flush).toHaveBeenCalled()
+      expect(wallet.publicDid).toBe('did:indy:test-ns:newdid') 
+    })
+    test('throws when create is called twice for the same wallet', async () => {
+      const wallet = { id: 'wallet-1', publicDid: null }
+      vi.mocked(em.findOneOrFail).mockResolvedValue(wallet)
+      vi.mocked(didRegistrarService.createDid).mockResolvedValue({
+        id: 'did:indy:test-ns:newdid',
+        verificationMethod: [{ id: 'did:indy:test-ns:newdid#key-1' }],
+      } as any)
+      vi.mocked(em.flush).mockResolvedValue(undefined)
+
+      const authInfo = { ...baseAuthInfo, role: Role.Admin }
+
+      await didService.create(authInfo as any, { method: 'indy' } as any)
+      await expect(didService.create(authInfo as any, { method: 'indy' } as any))
+        .rejects.toThrow('The wallet already contains created public DID: did:indy:test-ns:newdid')
     })
 
     test('throws UnprocessableEntityException when didControllerWallet is not found', async () => {

--- a/heka-identity-service/src/did/did.service.ts
+++ b/heka-identity-service/src/did/did.service.ts
@@ -164,7 +164,7 @@ export class DidService {
       })
     }
 
-    // wallet.publicDid = didDocument.id
+    wallet.publicDid = didDocument.id
     await this.em.flush()
 
     const res = new DidDocumentDto(didDocument)

--- a/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
+++ b/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common'
-
+import { Injectable, UnprocessableEntityException} from '@nestjs/common'
+import { EntityManager } from '@mikro-orm/core'
 import { TenantAgent } from 'common/agent'
 import { AuthInfo } from 'common/auth'
 import { InjectLogger, Logger } from 'common/logger'
@@ -24,6 +24,7 @@ export class PrepareWalletService {
     private readonly openId4VcVerifierService: OpenId4VcVerifierService,
     private readonly schemaV2Service: SchemaV2Service,
     private readonly userService: UserService,
+    private readonly em: EntityManager,
   ) {}
 
   public async prepareWallet(
@@ -57,6 +58,9 @@ export class PrepareWalletService {
             mainDid = did
           }
         } catch (error) {
+          if (error instanceof UnprocessableEntityException) {
+            throw error
+          }
           this.logger.error(`Failed to create DID for method ${method}`)
           continue
         }

--- a/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
+++ b/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, UnprocessableEntityException} from '@nestjs/common'
-import { EntityManager } from '@mikro-orm/core'
+
 import { TenantAgent } from 'common/agent'
 import { AuthInfo } from 'common/auth'
 import { InjectLogger, Logger } from 'common/logger'
@@ -24,7 +24,6 @@ export class PrepareWalletService {
     private readonly openId4VcVerifierService: OpenId4VcVerifierService,
     private readonly schemaV2Service: SchemaV2Service,
     private readonly userService: UserService,
-    private readonly em: EntityManager,
   ) {}
 
   public async prepareWallet(


### PR DESCRIPTION
**Description**:
Fix missing `publicDid` persistence to wallet entity after DID creation.

* Uncomment `wallet.publicDid = didDocument.id` assignment before `em.flush()` in `DidService.create()`
* Add assertion that `publicDid` is set on wallet after successful DID creation
* Add test proving duplicate guard correctly throws on second `create()` call for same wallet

**Related issue(s)**:
Fixes #114

**Notes for reviewer**:
The assignment was commented out with no explanation. Without it, every wallet is saved
with `publicDid: null` after DID creation — causing the duplicate DID guard to never
trigger and permanently breaking OrgAdmin/Issuer DID creation since controller resolution
depends on a persisted `publicDid`. Tests were confirmed red before the fix and green after.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
- Before 
<img width="1671" height="994" alt="issue before fix" src="https://github.com/user-attachments/assets/ea4f3e47-da27-4d75-9e64-b8fd910ce246" />

- after 
<img width="1666" height="732" alt="issue after fix" src="https://github.com/user-attachments/assets/d396d418-2c3a-4569-8de0-d19fa0406239" />

 