### PR TITLE
fix(types): replace @ts-ignore with @ts-expect-error in identity-service

### DIFF
--- a/heka-identity-service/src/common/did-registrar/did-registrar.service.ts
+++ b/heka-identity-service/src/common/did-registrar/did-registrar.service.ts
@@ -22,7 +22,7 @@ const DID_REGISTRAR_TENANT_LABEL = 'DidRegistrarTenant'
 @Injectable()
 export class DidRegistrarService implements OnApplicationBootstrap {
   private readonly registrars!: Record<string, DidRegistrar>
-  // @ts-ignore
+  // @ts-expect-error: assigned in onApplicationBootstrap, reserved for future use
   private tenantId!: string // FIXME: Currently unused but in future we want all DID to be created from separated tenant
   private readonly em!: EntityManager
 

--- a/heka-identity-service/src/revocation/status-list/status-list.service.ts
+++ b/heka-identity-service/src/revocation/status-list/status-list.service.ts
@@ -2,7 +2,7 @@
 
 // No type definitions available for this package
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+// @ts-expect-error: no type definitions available for this package
 import { Bitstring } from '@digitalcredentials/bitstring'
 import { EntityManager } from '@mikro-orm/core'
 import { BadRequestException, Inject, Injectable } from '@nestjs/common'


### PR DESCRIPTION
## Summary

Replaces simple `@ts-ignore` usages in identity-service with `@ts-expect-error` and explicit reasoning.

---

## Scope

- did-registrar.service.ts  
- status-list.service.ts  

---

## Changes

- replaced `@ts-ignore` with `@ts-expect-error`
- added clear comments explaining each suppression

---

## Notes

These cases involve known TypeScript limitations or missing external typings, where suppression is intentional. Using `@ts-expect-error` ensures the compiler will flag these if they ever become unnecessary.

---

## Validation

- `yarn build` → passes  
- no runtime behavior changes  

---

Related to #126 