### PR TITLE
fix(proof): correctly serialize complex credential attributes

### DIFF
--- a/heka-identity-service/src/proof/__tests__/proof.service.test.ts
+++ b/heka-identity-service/src/proof/__tests__/proof.service.test.ts
@@ -274,6 +274,38 @@ describe('ProofService', () => {
       expect(result.revealedAttributes).toContainEqual({ name: 'role', value: 'admin' })
     })
 
+    test('serializes complex credential attributes as JSON instead of [object Object]', async () => {
+      const mockRecord = proofExchangeRecordStub({ id: 'proof-3', state: 'done', createdAt: new Date() })
+      vi.mocked(tenantAgent.didcomm.proofs.findById).mockResolvedValue(mockRecord)
+      vi.mocked(tenantAgent.didcomm.proofs.getFormatData).mockResolvedValue({
+        presentation: {
+          presentationExchange: {
+            verifiableCredential: [
+              {
+                credentialSubject: {
+                  name: 'Alice',
+                  address: { street: '123 Main St', city: 'Springfield' },
+                  tags: ['verified', 'premium'],
+                },
+              },
+            ],
+          },
+        },
+      } as any)
+
+      const result = await proofService.get(tenantAgent, 'proof-3')
+
+      expect(result.revealedAttributes).toContainEqual({ name: 'name', value: 'Alice' })
+      expect(result.revealedAttributes).toContainEqual({
+        name: 'address',
+        value: JSON.stringify({ street: '123 Main St', city: 'Springfield' }),
+      })
+      expect(result.revealedAttributes).toContainEqual({
+        name: 'tags',
+        value: JSON.stringify(['verified', 'premium']),
+      })
+    })
+
     test('throws NotFoundException when proof not found', async () => {
       vi.mocked(tenantAgent.didcomm.proofs.findById).mockResolvedValue(null)
 

--- a/heka-identity-service/src/proof/proof.service.ts
+++ b/heka-identity-service/src/proof/proof.service.ts
@@ -27,6 +27,22 @@ import {
 } from './dto/proof-params.dto'
 import { ProofRequestFormat } from './dto/proof-request.dto'
 
+/**
+ * Safely serializes a credential attribute value to a string.
+ * Objects and arrays are JSON-stringified; primitives use String().
+ */
+function serializeAttributeValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
 @Injectable()
 export class ProofService {
   public async find(tenantAgent: TenantAgent, threadId?: string): Promise<ProofRecordDto[]> {
@@ -88,8 +104,7 @@ export class ProofService {
             for (const [attribute, value] of Object.entries(verifiableCredential.credentialSubject)) {
               proofRecordDto.revealedAttributes.push({
                 name: attribute,
-                // FIXME: Support all types
-                value: value?.toString() ?? '',
+                value: serializeAttributeValue(value),
               })
             }
           }


### PR DESCRIPTION
## Summary

Fixes incorrect `[object Object]` output when credential attributes contain nested values in the DIDComm presentation flow.

---

## Problem

`value?.toString()` produces incorrect or lossy output for non-primitive values:

- objects → `"[object Object]"`
- arrays → comma-joined string

---

## Changes

- introduced safe serialization for attribute values:
  - `null` / `undefined` → `''`
  - objects / arrays → `JSON.stringify()`
  - primitives → `String()`
- added fallback for circular structures
- replaced `.toString()` usage with this logic

---

## Notes

- preserves existing `value: string` contract (non-breaking)
- aligns behavior with OID4VC path which already supports complex values

---

## Tests

Added unit test covering:
- primitive value (regression)
- nested object
- array

---

## Validation

- `yarn build` → passes  
- `vitest` → all tests pass  

---

Fixes #128