### PR TITLE
feat(web-ui): add debounce search for templates

### DIFF
--- a/heka-identity-service-web-ui/src/components/Templates/Templates.module.scss
+++ b/heka-identity-service-web-ui/src/components/Templates/Templates.module.scss
@@ -5,13 +5,34 @@
   overflow-y: auto;
 }
 
+@import '@/shared/styles/mixins';
+
 .templatesHeaderWrapper {
   justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-xxxxl);
 }
 
 .templatesHeaderLeft {
   gap: var(--space-md);
-  margin-bottom: var(--space-xxxxl);
+  align-items: center;
+}
+
+@include mobile {
+  .TemplatesWrapper {
+    padding: var(--space-xl);
+  }
+
+  .templatesHeaderWrapper {
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .templatesHeaderLeft {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 .schemaTitle {

--- a/heka-identity-service-web-ui/src/components/Templates/Templates.tsx
+++ b/heka-identity-service-web-ui/src/components/Templates/Templates.tsx
@@ -12,6 +12,7 @@ import { VerificationTemplate } from '@/entities/VerificationTemplate';
 import useConfirmDialog from '@/shared/ui/ConfirmDialog';
 import { Column, Row } from '@/shared/ui/Grid';
 import { LoaderView } from '@/shared/ui/Loader';
+import { Search } from '@/shared/ui/Search/Search';
 
 import { TemplatesProps, TemplateType } from './types';
 import { PlusButton } from '../PlusButton';
@@ -33,6 +34,7 @@ export const Templates = ({
   const { templates, isLoading, error } = templatesState;
 
   const [localTemplates, setLocalTemplates] = useState(templates ?? []);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const [deletingTemplateId, setDeletingTemplateId] = useState<
     string | undefined
@@ -55,6 +57,13 @@ export const Templates = ({
   useEffect(() => {
     if (templates) setLocalTemplates(templates);
   }, [templates]);
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredTemplates = normalizedQuery
+    ? localTemplates.filter((t) =>
+        (t.name ?? '').toLowerCase().includes(normalizedQuery),
+      )
+    : localTemplates;
 
   const { ConfirmDialog, confirm } = useConfirmDialog({
     text: t('Template.confirmation.deleteTemplate'),
@@ -132,6 +141,7 @@ export const Templates = ({
             onPress={() => navigate(navigateOnCreateTemplate)}
           />
         </Row>
+        <Search onSearch={setSearchQuery} />
       </Row>
       {isLoading && <LoaderView />}
       {!!error && !isLoading && <h2>{t('Common.titles.smthWentWrong')}</h2>}
@@ -151,10 +161,10 @@ export const Templates = ({
               />
             </DesktopView>
           )}
-          {localTemplates.length > 0 && (
+          {filteredTemplates.length > 0 && (
             <DndContext onDragEnd={handleDragEnd}>
-              <SortableContext items={localTemplates}>
-                {localTemplates.map((template) => (
+              <SortableContext items={filteredTemplates}>
+                {filteredTemplates.map((template) => (
                   <Template
                     key={template.id}
                     id={template.id}

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.module.scss
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.module.scss
@@ -1,12 +1,28 @@
+@import '@/shared/styles/mixins';
+
 .SearchWrapper {
   position: relative;
   height: var(--space-xxxxl);
 }
 
 .searchInput {
-  padding: var(--space-sm) var(--space-md);
-  border-radius: var(--space-sm);
-  border: 1px solid #00000061;
+  min-width: 260px;
+  max-width: 100%;
+
+  &::placeholder {
+    opacity: 1;
+  }
+}
+
+@include mobile {
+  .SearchWrapper {
+    width: 100%;
+  }
+
+  .searchInput {
+    min-width: 0;
+    width: 100%;
+  }
 }
 
 // .searchIcon {

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
@@ -10,14 +10,24 @@ jest.mock(
 import { Search } from './Search';
 
 describe('Search', () => {
-  test('triggers onSearch callback on input changes', async () => {
-    const user = userEvent.setup();
+  test('debounces onSearch callback on input changes', async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const onSearch = jest.fn();
 
-    render(<Search onSearch={onSearch} />);
+    render(<Search onSearch={onSearch} debounceMs={300} />);
 
     await user.type(screen.getByPlaceholderText('Search'), 'ab');
 
-    expect(onSearch).toHaveBeenCalledTimes(2);
+    expect(onSearch).toHaveBeenCalledTimes(0);
+
+    jest.advanceTimersByTime(299);
+    expect(onSearch).toHaveBeenCalledTimes(0);
+
+    jest.advanceTimersByTime(1);
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenLastCalledWith('ab');
+
+    jest.useRealTimers();
   });
 });

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
@@ -22,7 +22,7 @@ export const Search = ({ onSearch, debounceMs = 300 }: SearchProps) => {
 
   return (
     <div className={cls.SearchWrapper}>
-      <TextInputUncontrolled
+      <TextInputUncontrolled // Implemented Debounce Search
         label="Search"
         initValue={query}
         onChange={setQuery}

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
@@ -1,17 +1,32 @@
+import { useEffect, useState } from 'react';
+
 import { TextInputUncontrolled } from '@/shared/ui/TextInput';
 
 import * as cls from './Search.module.scss';
 
 interface SearchProps {
-  onSearch: () => void;
+  onSearch: (query: string) => void;
+  debounceMs?: number;
 }
 
-export const Search = ({ onSearch }: SearchProps) => {
+export const Search = ({ onSearch, debounceMs = 300 }: SearchProps) => {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(query);
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [debounceMs, onSearch, query]);
+
   return (
     <div className={cls.SearchWrapper}>
       <TextInputUncontrolled
         label="Search"
-        onChange={onSearch} // TODO: use debounce
+        initValue={query}
+        onChange={setQuery}
+        className={cls.searchInput}
       />
     </div>
   );


### PR DESCRIPTION
**Description**:
Add a debounced search input to the Templates screen to make it easier to find templates without triggering filtering logic on every keystroke.
* Add debounced `Search` component API (`onSearch(query)`, configurable delay)
* Render Search in Templates header and filter templates list client-side by name
* Fix Search placeholder visibility and prevent mobile horizontal overflow via responsive styles
* Add unit test coverage for debounce behavior

**Related issue(s)**:

Fixes #134 

**Notes for reviewer**:
* Manual test: Issue Credential → Templates → type in Search; list updates after ~300ms
* Mobile: header wraps and Search becomes full width (no horizontal scrolling)
* Tests: `yarn test:unit`

**Screenshot (ui)**: 
<img width="977" height="516" alt="Screenshot 2026-05-06 234505" src="https://github.com/user-attachments/assets/56e82a22-a463-468e-8463-815b8bdef6cd" />


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
