### PR TITLE
fix(auth): handle string[] Authorization header in BearerGuard

### DIFF
--- a/heka-auth-service/src/oauth/guards/bearer.guard.ts
+++ b/heka-auth-service/src/oauth/guards/bearer.guard.ts
@@ -18,7 +18,7 @@ export class BearerGuard implements CanActivate {
 export function extractTokenFromRequest(request: IncomingMessage): string {
   const header = request.headers[AuthorizationHeader]
   if (!header || Array.isArray(header)) throw new UnauthorizedException()
-  
+
   const [type, token] = header.trim().split(/\s+/)
   if (!type || type.toLowerCase() !== AuthorizationTokenType.toLowerCase()) {
     throw new UnauthorizedException()

--- a/heka-auth-service/src/oauth/guards/bearer.guard.ts
+++ b/heka-auth-service/src/oauth/guards/bearer.guard.ts
@@ -17,10 +17,8 @@ export class BearerGuard implements CanActivate {
 
 export function extractTokenFromRequest(request: IncomingMessage): string {
   const header = request.headers[AuthorizationHeader]
-  if (!header) {
-    throw new UnauthorizedException()
-  }
-
+  if (!header || Array.isArray(header)) throw new UnauthorizedException()
+  
   const [type, token] = header.trim().split(/\s+/)
   if (!type || type.toLowerCase() !== AuthorizationTokenType.toLowerCase()) {
     throw new UnauthorizedException()

--- a/heka-auth-service/test/unit/bearer.guard.spec.ts
+++ b/heka-auth-service/test/unit/bearer.guard.spec.ts
@@ -55,4 +55,8 @@ describe('extractTokenFromRequest', () => {
 
     expect(() => extractTokenFromRequest(request)).toThrow(UnauthorizedException)
   })
+  it('should throw UnauthorizedException when Authorization header is an array', () => {
+  const request = { headers: { authorization: ['Bearer token1', 'Bearer token2'] } } as unknown as IncomingMessage
+  expect(() => extractTokenFromRequest(request)).toThrow(UnauthorizedException)
+})
 })


### PR DESCRIPTION
## Description
Handle `string[]` Authorization header in `BearerGuard` to explicitly reject array values with `401 UnauthorizedException` instead of masking a `TypeError`.

* Add `Array.isArray(header)` check alongside existing null guard in `extractTokenFromRequest`
* Add unit test covering `string[]` Authorization header case

## Related issue(s)
Fixes #140

## Notes for reviewer
In Node.js, `request.headers` values are typed as `string | string[] | undefined`. Prior to this fix, passing an array as the `Authorization` header caused `header.trim()` to throw a `TypeError`, which was silently caught and re-thrown as `UnauthorizedException`. The guard now explicitly rejects array headers before attempting to parse them.

Follows up on PR #124.

## Checklist
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)