### PR TITLE
test(auth): guard e2e teardown and document local test setup

### DIFF
--- a/heka-auth-service/README.md
+++ b/heka-auth-service/README.md
@@ -161,3 +161,35 @@ To run the service in Docker:
 ```bash
 docker compose -f docker-compose.dev.yml up -d
 ```
+
+## Testing
+
+### Unit tests
+
+```bash
+yarn test
+```
+
+### E2E tests
+
+E2E tests require a running Postgres instance. The quickest way is to reuse the container from [Quick Start](#quick-start):
+
+```bash
+docker run --name heka-auth-service-postgres \
+  -e POSTGRES_DB=heka-auth-service \
+  -e POSTGRES_USER=heka \
+  -e POSTGRES_PASSWORD=heka1 \
+  -p 5433:5432 -d postgres
+```
+
+Since the Quick Start container maps to host port `5433`, override the default when running tests locally:
+
+```bash
+MIKRO_ORM_HOST=127.0.0.1 MIKRO_ORM_PORT=5433 yarn test
+```
+
+If your Postgres is on the standard port `5432`, no override is needed:
+
+```bash
+yarn test
+```

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -28,8 +28,8 @@ describe('E2E authorization', () => {
   })
 
   afterAll(async () => {
-    await nestApp.close()
-    await ormSchemaGenerator.clearDatabase()
+    if (nestApp) await nestApp.close()
+    if (ormSchemaGenerator) await ormSchemaGenerator.clearDatabase()
   })
 
   const newUser = () => ({


### PR DESCRIPTION
## Description
Harden E2E test teardown and document local test setup for the auth service.

* Guard `afterAll` teardown with null checks to prevent crashes when `beforeAll` fails early
* Add Testing section to README covering unit and E2E test commands, including local Postgres port override

## Related issue(s)
N/A — no issue needed for this cleanup

## Notes for reviewer
Without the null guards, a failed `beforeAll` (e.g. DB unreachable) caused `afterAll` to crash on `nestApp.close()`, hiding the actual failure. The fix ensures teardown is safe regardless of setup outcome.

E2E tests confirmed passing locally:
- ✓ auth flow
- ✓ login fails with wrong password  
- ✓ profile endpoint requires authentication

## Checklist
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)