### PR TITLE
feat: add debounced template search

### DIFF
--- a/heka-identity-service-web-ui/src/components/Templates/Templates.tsx
+++ b/heka-identity-service-web-ui/src/components/Templates/Templates.tsx
@@ -1,6 +1,6 @@
 import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext } from '@dnd-kit/sortable';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -12,6 +12,7 @@ import { VerificationTemplate } from '@/entities/VerificationTemplate';
 import useConfirmDialog from '@/shared/ui/ConfirmDialog';
 import { Column, Row } from '@/shared/ui/Grid';
 import { LoaderView } from '@/shared/ui/Loader';
+import { Search } from '@/shared/ui/Search/Search';
 
 import { TemplatesProps, TemplateType } from './types';
 import { PlusButton } from '../PlusButton';
@@ -33,6 +34,7 @@ export const Templates = ({
   const { templates, isLoading, error } = templatesState;
 
   const [localTemplates, setLocalTemplates] = useState(templates ?? []);
+  const [searchQuery, setSearchQuery] = useState('');
 
   const [deletingTemplateId, setDeletingTemplateId] = useState<
     string | undefined
@@ -55,6 +57,16 @@ export const Templates = ({
   useEffect(() => {
     if (templates) setLocalTemplates(templates);
   }, [templates]);
+
+  const filteredTemplates = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    if (!query) return localTemplates;
+
+    return localTemplates.filter((t) =>
+      t.name.toLowerCase().includes(query),
+    );
+  }, [localTemplates, searchQuery]);
 
   const { ConfirmDialog, confirm } = useConfirmDialog({
     text: t('Template.confirmation.deleteTemplate'),
@@ -84,10 +96,17 @@ export const Templates = ({
       const newIndex = event.over?.data.current?.sortable.index ?? 0;
 
       let previousTemplateId;
+
       setLocalTemplates((templates) => {
-        const updatedLocalTemplates = arrayMove(templates, oldIndex, newIndex);
+        const updatedLocalTemplates = arrayMove(
+          templates,
+          oldIndex,
+          newIndex,
+        );
+
         previousTemplateId =
           newIndex === 0 ? null : updatedLocalTemplates[newIndex - 1].id;
+
         return updatedLocalTemplates;
       });
 
@@ -127,17 +146,25 @@ export const Templates = ({
       <Row className={cls.templatesHeaderWrapper}>
         <Row className={cls.templatesHeaderLeft}>
           <p className={cls.schemaTitle}>{t('Common.titles.templates')}</p>
+
           <PlusButton
             title={t('Template.buttons.create')}
             onPress={() => navigate(navigateOnCreateTemplate)}
           />
         </Row>
+
+        <Search onSearch={setSearchQuery} />
       </Row>
+
       {isLoading && <LoaderView />}
-      {!!error && !isLoading && <h2>{t('Common.titles.smthWentWrong')}</h2>}
+
+      {!!error && !isLoading && (
+        <h2>{t('Common.titles.smthWentWrong')}</h2>
+      )}
+
       {!isLoading && !error && (
         <div className={cls.templateItemsContainer}>
-          {localTemplates.length === 0 && (
+          {filteredTemplates.length === 0 && (
             <DesktopView>
               <NoItemFound
                 title={t('Template.titles.noTemplates')}
@@ -151,10 +178,11 @@ export const Templates = ({
               />
             </DesktopView>
           )}
-          {localTemplates.length > 0 && (
+
+          {filteredTemplates.length > 0 && (
             <DndContext onDragEnd={handleDragEnd}>
-              <SortableContext items={localTemplates}>
-                {localTemplates.map((template) => (
+              <SortableContext items={filteredTemplates}>
+                {filteredTemplates.map((template) => (
                   <Template
                     key={template.id}
                     id={template.id}
@@ -170,6 +198,7 @@ export const Templates = ({
           )}
         </div>
       )}
+
       <ConfirmDialog />
     </Column>
   );

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.module.scss
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.module.scss
@@ -1,14 +1,36 @@
 .SearchWrapper {
   position: relative;
   height: var(--space-xxxxl);
+  width: 100%;
+  min-width: 0;
 }
 
 .searchInput {
+  width: 100%;
+  min-width: 0;
+
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--space-sm);
   border: 1px solid #00000061;
+
+  &::placeholder {
+    color: #0009;
+    opacity: 1;
+  }
 }
 
 // .searchIcon {
-//     transform: scale(2);
+//   transform: scale(2);
 // }
+
+@media (width <= 768px) {
+  .SearchWrapper {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .searchInput {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-jest.mock('@/shared/assets/icons/visibility-off.svg', () => 'visibility-off.svg');
+jest.mock(
+  '@/shared/assets/icons/visibility-off.svg',
+  () => 'visibility-off.svg',
+);
+
 jest.mock(
   '@/shared/assets/icons/visibility-outline.svg',
   () => 'visibility-outline.svg',
@@ -10,14 +14,33 @@ jest.mock(
 import { Search } from './Search';
 
 describe('Search', () => {
-  test('triggers onSearch callback on input changes', async () => {
-    const user = userEvent.setup();
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('does not call onSearch immediately and fires once after debounce with final query', async () => {
     const onSearch = jest.fn();
 
-    render(<Search onSearch={onSearch} />);
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
+    render(<Search onSearch={onSearch} debounceMs={300} />);
 
     await user.type(screen.getByPlaceholderText('Search'), 'ab');
 
-    expect(onSearch).toHaveBeenCalledTimes(2);
+    expect(onSearch).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('ab');
   });
 });

--- a/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Search/Search.tsx
@@ -1,17 +1,34 @@
+import { useEffect, useState } from 'react';
+
 import { TextInputUncontrolled } from '@/shared/ui/TextInput';
 
 import * as cls from './Search.module.scss';
 
 interface SearchProps {
-  onSearch: () => void;
+  onSearch: (query: string) => void;
+  debounceMs?: number;
 }
 
-export const Search = ({ onSearch }: SearchProps) => {
+export const Search = ({
+  onSearch,
+  debounceMs = 300,
+}: SearchProps) => {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(query);
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [query, debounceMs, onSearch]);
+
   return (
     <div className={cls.SearchWrapper}>
       <TextInputUncontrolled
         label="Search"
-        onChange={onSearch} // TODO: use debounce
+        value={query}
+        onChange={setQuery}
       />
     </div>
   );


### PR DESCRIPTION
**Description**:

Add debounced search functionality to the templates page.

* Add internal query state to Search component
* Add configurable debounce support
* Add responsive/mobile styles for search input
* Add case-insensitive template filtering
* Add debounce unit tests using fake timers

**Related issue(s)**:

Fixes #135

**Notes for reviewer**:

Tested locally with:

* `yarn test:unit`
* `yarn lint:ts`
* `yarn lint:scss`

**Checklist**

* [x] Documented (Code comments, README, etc.)
* [x] Tested (unit, integration, etc.)
