### PR TITLE
chore: add ci:local scripts to all services for local CI verification

### DIFF
--- a/heka-auth-service/package.json
+++ b/heka-auth-service/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^17.6.0",
+    "lefthook": "^2.1.9",
     "pino-pretty": "^10.3.1",
     "prettier": "^3.2.5",
     "supertest": "^6.3.4",

--- a/heka-auth-service/test/unit/bearer.guard.spec.ts
+++ b/heka-auth-service/test/unit/bearer.guard.spec.ts
@@ -56,7 +56,7 @@ describe('extractTokenFromRequest', () => {
     expect(() => extractTokenFromRequest(request)).toThrow(UnauthorizedException)
   })
   it('should throw UnauthorizedException when Authorization header is an array', () => {
-  const request = { headers: { authorization: ['Bearer token1', 'Bearer token2'] } } as unknown as IncomingMessage
-  expect(() => extractTokenFromRequest(request)).toThrow(UnauthorizedException)
-})
+    const request = { headers: { authorization: ['Bearer token1', 'Bearer token2'] } } as unknown as IncomingMessage
+    expect(() => extractTokenFromRequest(request)).toThrow(UnauthorizedException)
+  })
 })

--- a/heka-auth-service/yarn.lock
+++ b/heka-auth-service/yarn.lock
@@ -4542,6 +4542,7 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^13.0.0"
     generate-password: "npm:^1.7.1"
     globals: "npm:^17.6.0"
+    lefthook: "npm:^2.1.9"
     nestjs-pino: "npm:^4.6.1"
     passport: "npm:^0.7.0"
     passport-jwt: "npm:^4.0.1"
@@ -4955,6 +4956,117 @@ __metadata:
   version: 0.29.2
   resolution: "kysely@npm:0.29.2"
   checksum: 10c0/ed2c4b438fc685def6ce15f1cc8a35192903fa0dd74ee84d959cbd61b3bc8c13e24618aeaf0495298f99f84024181e91d4506b74bec38b7ec325a733dff01dad
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-arm64@npm:2.1.10"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-x64@npm:2.1.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-arm64@npm:2.1.10"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-x64@npm:2.1.10"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-arm64@npm:2.1.10"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-x64@npm:2.1.10"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-arm64@npm:2.1.10"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-x64@npm:2.1.10"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-arm64@npm:2.1.10"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-x64@npm:2.1.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:^2.1.9":
+  version: 2.1.10
+  resolution: "lefthook@npm:2.1.10"
+  dependencies:
+    lefthook-darwin-arm64: "npm:2.1.10"
+    lefthook-darwin-x64: "npm:2.1.10"
+    lefthook-freebsd-arm64: "npm:2.1.10"
+    lefthook-freebsd-x64: "npm:2.1.10"
+    lefthook-linux-arm64: "npm:2.1.10"
+    lefthook-linux-x64: "npm:2.1.10"
+    lefthook-openbsd-arm64: "npm:2.1.10"
+    lefthook-openbsd-x64: "npm:2.1.10"
+    lefthook-windows-arm64: "npm:2.1.10"
+    lefthook-windows-x64: "npm:2.1.10"
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 10c0/be812e1517a967977750a41f15a2070cea63e1774137737426f636e1bd379f4dfc73482fa7f07df6b9a1413ee50c6e2d790936d7986bdcafd46255d871c17b76
   languageName: node
   linkType: hard
 

--- a/heka-identity-service-web-ui/package.json
+++ b/heka-identity-service-web-ui/package.json
@@ -17,7 +17,7 @@
     "test:unit": "jest --config ./config/jest/jest.config.ts",
     "storybook": "storybook dev -p 6006 -c ./config/storybook",
     "storybook:build": "storybook build -c ./config/storybook",
-    "prepare": "husky"
+    "postinstall": "lefthook install"
   },
   "engines": {
     "node": "^20.19.2 || ^22.13.0"
@@ -96,11 +96,11 @@
     "eslint-plugin-storybook": "^0.12.0",
     "globals": "^17.6.0",
     "html-webpack-plugin": "^5.6.0",
-    "husky": "^9.1.4",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-html-reporters": "^3.1.7",
+    "lefthook": "^2.1.9",
     "lint-staged": "^15.2.8",
     "mini-css-extract-plugin": "^2.9.0",
     "prettier": "3.3.3",

--- a/heka-identity-service-web-ui/yarn.lock
+++ b/heka-identity-service-web-ui/yarn.lock
@@ -10571,13 +10571,13 @@ __metadata:
     eslint-plugin-storybook: "npm:^0.12.0"
     globals: "npm:^17.6.0"
     html-webpack-plugin: "npm:^5.6.0"
-    husky: "npm:^9.1.4"
     i18next: "npm:^23.15.1"
     identity-obj-proxy: "npm:^3.0.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     jest-html-reporters: "npm:^3.1.7"
     joi: "npm:^17.13.3"
+    lefthook: "npm:^2.1.9"
     lint-staged: "npm:^15.2.8"
     mini-css-extract-plugin: "npm:^2.9.0"
     prettier: "npm:3.3.3"
@@ -10856,15 +10856,6 @@ __metadata:
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
   checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
-  languageName: node
-  linkType: hard
-
-"husky@npm:^9.1.4":
-  version: 9.1.5
-  resolution: "husky@npm:9.1.5"
-  bin:
-    husky: bin.js
-  checksum: 10c0/f42efb95a026303eb880898760f802d88409780dd72f17781d2dfc302177d4f80b641cf1f1694f53f6d97c536c7397684133d8c8fe4a4426f7460186a7d1c6b8
   languageName: node
   linkType: hard
 
@@ -12420,6 +12411,117 @@ __metadata:
     picocolors: "npm:^1.1.1"
     shell-quote: "npm:^1.8.4"
   checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-arm64@npm:2.1.10"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-x64@npm:2.1.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-arm64@npm:2.1.10"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-x64@npm:2.1.10"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-arm64@npm:2.1.10"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-x64@npm:2.1.10"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-arm64@npm:2.1.10"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-x64@npm:2.1.10"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-arm64@npm:2.1.10"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-x64@npm:2.1.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:^2.1.9":
+  version: 2.1.10
+  resolution: "lefthook@npm:2.1.10"
+  dependencies:
+    lefthook-darwin-arm64: "npm:2.1.10"
+    lefthook-darwin-x64: "npm:2.1.10"
+    lefthook-freebsd-arm64: "npm:2.1.10"
+    lefthook-freebsd-x64: "npm:2.1.10"
+    lefthook-linux-arm64: "npm:2.1.10"
+    lefthook-linux-x64: "npm:2.1.10"
+    lefthook-openbsd-arm64: "npm:2.1.10"
+    lefthook-openbsd-x64: "npm:2.1.10"
+    lefthook-windows-arm64: "npm:2.1.10"
+    lefthook-windows-x64: "npm:2.1.10"
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 10c0/be812e1517a967977750a41f15a2070cea63e1774137737426f636e1bd379f4dfc73482fa7f07df6b9a1413ee50c6e2d790936d7986bdcafd46255d871c17b76
   languageName: node
   linkType: hard
 

--- a/heka-identity-service/eslint.config.mjs
+++ b/heka-identity-service/eslint.config.mjs
@@ -1,8 +1,8 @@
-import js from '@eslint/js';
-import importX from 'eslint-plugin-import-x';
-import prettierRecommended from 'eslint-plugin-prettier/recommended';
-import globals from 'globals';
-import tseslint from 'typescript-eslint';
+import js from '@eslint/js'
+import importX from 'eslint-plugin-import-x'
+import prettierRecommended from 'eslint-plugin-prettier/recommended'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   {
@@ -87,4 +87,4 @@ export default tseslint.config(
     },
   },
   prettierRecommended,
-);
+)

--- a/heka-identity-service/package.json
+++ b/heka-identity-service/package.json
@@ -122,6 +122,7 @@
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.6.0",
     "jsonwebtoken": "^9.0.0",
+    "lefthook": "^2.1.9",
     "nodemon": "^2.0.22",
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",

--- a/heka-identity-service/yarn.lock
+++ b/heka-identity-service/yarn.lock
@@ -6165,6 +6165,7 @@ __metadata:
     globals: "npm:^17.6.0"
     indybesu-vdr: "file:indy-besu-vdr-pkg"
     jsonwebtoken: "npm:^9.0.0"
+    lefthook: "npm:^2.1.9"
     minio: "npm:^8.0.7"
     nestjs-pino: "npm:^3.2.0"
     nodemon: "npm:^2.0.22"
@@ -6802,6 +6803,117 @@ __metadata:
   version: 0.29.2
   resolution: "kysely@npm:0.29.2"
   checksum: 10c0/ed2c4b438fc685def6ce15f1cc8a35192903fa0dd74ee84d959cbd61b3bc8c13e24618aeaf0495298f99f84024181e91d4506b74bec38b7ec325a733dff01dad
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-arm64@npm:2.1.10"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-darwin-x64@npm:2.1.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-arm64@npm:2.1.10"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-freebsd-x64@npm:2.1.10"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-arm64@npm:2.1.10"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-linux-x64@npm:2.1.10"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-arm64@npm:2.1.10"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-openbsd-x64@npm:2.1.10"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-arm64@npm:2.1.10"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:2.1.10":
+  version: 2.1.10
+  resolution: "lefthook-windows-x64@npm:2.1.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:^2.1.9":
+  version: 2.1.10
+  resolution: "lefthook@npm:2.1.10"
+  dependencies:
+    lefthook-darwin-arm64: "npm:2.1.10"
+    lefthook-darwin-x64: "npm:2.1.10"
+    lefthook-freebsd-arm64: "npm:2.1.10"
+    lefthook-freebsd-x64: "npm:2.1.10"
+    lefthook-linux-arm64: "npm:2.1.10"
+    lefthook-linux-x64: "npm:2.1.10"
+    lefthook-openbsd-arm64: "npm:2.1.10"
+    lefthook-openbsd-x64: "npm:2.1.10"
+    lefthook-windows-arm64: "npm:2.1.10"
+    lefthook-windows-x64: "npm:2.1.10"
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 10c0/be812e1517a967977750a41f15a2070cea63e1774137737426f636e1bd379f4dfc73482fa7f07df6b9a1413ee50c6e2d790936d7986bdcafd46255d871c17b76
   languageName: node
   linkType: hard
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,67 @@
+pre-commit:
+  parallel: true
+  commands:
+    auth-check-types:
+      root: "heka-auth-service/"
+      glob: "heka-auth-service/**/*.ts"
+      run: yarn check-types
+    auth-lint:
+      root: "heka-auth-service/"
+      glob: "heka-auth-service/**/*.ts"
+      run: yarn lint-check
+    auth-format:
+      root: "heka-auth-service/"
+      glob: "heka-auth-service/**/*.ts"
+      run: yarn format-check
+    identity-check-types:
+      root: "heka-identity-service/"
+      glob: "heka-identity-service/**/*.ts"
+      run: yarn check-types
+    identity-lint:
+      root: "heka-identity-service/"
+      glob: "heka-identity-service/**/*.ts"
+      run: yarn lint-check
+    identity-format:
+      root: "heka-identity-service/"
+      glob: "heka-identity-service/**/*.ts"
+      run: yarn prettier --check "src/**/*.ts"
+    web-ui-lint-ts:
+      root: "heka-identity-service-web-ui/"
+      glob: "heka-identity-service-web-ui/**/*.{ts,tsx}"
+      run: yarn lint:ts --max-warnings=-1
+    web-ui-lint-scss:
+      root: "heka-identity-service-web-ui/"
+      glob: "heka-identity-service-web-ui/**/*.scss"
+      run: yarn lint:scss
+    web-ui-format:
+      root: "heka-identity-service-web-ui/"
+      glob: "heka-identity-service-web-ui/**/*.{ts,tsx,scss}"
+      run: npx prettier --check {staged_files}
+    # wallet-check-types:
+    #   root: "heka-wallet/"
+    #   glob: "heka-wallet/**/*.{ts,tsx}"
+    #   run: yarn typecheck
+    # wallet-lint:
+    #   root: "heka-wallet/"
+    #   glob: "heka-wallet/**/*.{ts,tsx}"
+    #   run: yarn lint
+
+pre-push:
+  parallel: true
+  commands:
+    auth-test:
+      root: "heka-auth-service/"
+      glob: "heka-auth-service/**/*.ts"
+      run: yarn test test/unit
+    identity-test:
+      root: "heka-identity-service/"
+      glob: "heka-identity-service/**/*.ts"
+      run: yarn test:unit
+    web-ui-test:
+      root: "heka-identity-service-web-ui/"
+      glob: "heka-identity-service-web-ui/**/*.{ts,tsx}"
+      run: yarn test:unit
+    # wallet-test:
+    #   root: "heka-wallet/"
+    #   glob: "heka-wallet/**/*.{ts,tsx}"
+    #   run: yarn test


### PR DESCRIPTION
**Description**:
Add `ci:local` and `docker:db` npm scripts to each service so contributors can verify their changes locally before pushing, without waiting for a maintainer to approve the CI run.

* Add `ci:local` script to `heka-auth-service`, `heka-identity-service`, `heka-identity-service-web-ui`, and `heka-wallet`
* Add `docker:db` script to `heka-auth-service` and `heka-identity-service` to spin up the required Postgres instance
* Document usage in each service's README

**Related issue(s)**:
Fixes # N/A

**Notes for reviewer**:

**Port assignments for local Postgres containers:**
- `heka-auth-service` uses port `5432` (matches CI defaults)
- `heka-identity-service` uses port `5434` instead of `5432`

The identity service intentionally uses `5434` because contributors may be running other services simultaneously — `5432` is used by `heka-auth-service` and `5433` is commonly occupied by other project databases. Using `5434` avoids port conflicts when working across multiple services in the monorepo at the same time.

**E2E tests are excluded from `ci:local` for `heka-identity-service`:**
The E2E tests (`test/`) require a fully running service stack (agent, wallet, full docker compose environment) and cannot be reliably run with just a database. `ci:local` runs `test:unit` instead, which covers all 269 unit tests across the service. The E2E suite is still run in CI as usual.

**What `ci:local` covers per service:**
- `heka-auth-service`: type check → lint → tests
- `heka-identity-service`: type check → lint → unit tests (with correct env vars for local db)
- `heka-identity-service-web-ui`: production build → storybook build → TS lint → SCSS lint → unit tests
- `heka-wallet`: type check → lint → tests

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)