### PR TITLE
fix(dto): missing @IsString() validators on DTO fields allows non-string input

### DIFF
--- a/heka-auth-service/src/oauth/dto/login.ts
+++ b/heka-auth-service/src/oauth/dto/login.ts
@@ -1,14 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { Length } from 'class-validator'
+import { IsString, Length } from 'class-validator'
 
 import { Token } from './token'
 
 export class LoginRequest {
   @ApiProperty()
+  @IsString()
   @Length(1, 255)
   public readonly name!: string
 
   @ApiProperty()
+  @IsString()
   @Length(1, 255)
   public readonly password!: string
 }

--- a/heka-auth-service/src/user/dto/register.ts
+++ b/heka-auth-service/src/user/dto/register.ts
@@ -1,10 +1,11 @@
 import { passwordValidationRules } from '@common/const/password.const'
 import { UserRole } from '@core/database'
 import { ApiProperty } from '@nestjs/swagger'
-import { IsEnum, IsOptional, IsStrongPassword, Length } from 'class-validator'
+import { IsEnum, IsOptional, IsString, IsStrongPassword, Length } from 'class-validator'
 
 export class RegisterUserRequest {
   @ApiProperty()
+  @IsString()
   @Length(1, 255)
   public readonly name!: string
 

--- a/heka-auth-service/src/user/dto/request-change-password.ts
+++ b/heka-auth-service/src/user/dto/request-change-password.ts
@@ -3,10 +3,12 @@ import { IsString, Length } from 'class-validator'
 
 export class RequestChangePasswordRequest {
   @ApiProperty()
+  @IsString()
   @Length(1, 255)
   public readonly name!: string
 
   @ApiProperty()
+  @IsString()
   @Length(1, 255)
   public readonly oldPassword!: string
 }


### PR DESCRIPTION
**Description**:
Add missing @IsString() validators to DTO fields.

* Add @IsString() above @Length() in login.ts (name, password)
* Add @IsString() above @Length() in register.ts (name)
* Add @IsString() above @Length() in request-change-password.ts (name, oldPassword)

**Related issue(s)**:
Fixes #148

**Notes for reviewer**:
One-line change per field, no logic touched.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)