### PR TITLE
Fix network-specific schemas pre-registration

### DIFF
--- a/heka-identity-service-web-ui/src/entities/Credential/model/services/offerCredential.ts
+++ b/heka-identity-service-web-ui/src/entities/Credential/model/services/offerCredential.ts
@@ -2,7 +2,6 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosInstance } from 'axios';
 
 import { ThunkConfig } from '@/app/providers/StoreProvider';
-import { demoUser } from '@/const/user';
 import {
   buildCredential,
   BuildCredentialParams,
@@ -22,7 +21,6 @@ import {
 } from '@/entities/Schema/model/types/schema';
 import { agencyEndpoints } from '@/shared/api/config/endpoints';
 import { handleError } from '@/shared/api/utils/error';
-import { getUserId } from '@/shared/api/utils/token';
 
 import {
   AnoncredsCredentialState,
@@ -79,11 +77,6 @@ const offerOpenId4VcCredential = async (
   api: AxiosInstance,
   params: OfferCredentialParams,
 ): Promise<OfferCredentialResult> => {
-  const userId = params.useDemo ? demoUser.did : getUserId();
-  if (!userId) {
-    throw new Error('User ID is not set');
-  }
-
   const schemaRegistration = await getSchemaRegistration(api, {
     ...params,
     credentialFormat: credentialFormatToCredentialRegistrationFormat(
@@ -101,7 +94,7 @@ const offerOpenId4VcCredential = async (
     namespace: params.schema.name,
   } as BuildCredentialParams);
   const body = buildOpenIdCredentialOffer({
-    id: userId,
+    id: params.did,
     credentials: [credential],
   });
   const response = await api.post<OfferOpenId4VcCredentialResponse>(

--- a/heka-identity-service/docs/swagger-spec.yaml
+++ b/heka-identity-service/docs/swagger-spec.yaml
@@ -3700,12 +3700,7 @@ components:
             - direct_post.jwt
             - dc_api
             - dc_api.jwt
-          description: Response mode for the authorization request. Use dc_api or
-            dc_api.jwt for Digital Credentials API flow.
         expectedOrigins:
-          description: Expected origins embedded in a signed request (signed DC API binds
-            the calling page here). Ignored for the unsigned DC API flow, where
-            the origin is validated at verification time.
           type: array
           items:
             type: string
@@ -3763,11 +3758,8 @@ components:
       properties:
         authorizationResponse:
           type: object
-          description: The authorization response received from navigator.credentials.get()
         origin:
           type: string
-          description: The origin of the verifier page that called
-            navigator.credentials.get()
       required:
         - authorizationResponse
         - origin

--- a/heka-identity-service/src/prepare-wallet/__tests__/prepare-wallet.service.test.ts
+++ b/heka-identity-service/src/prepare-wallet/__tests__/prepare-wallet.service.test.ts
@@ -207,4 +207,60 @@ describe('PrepareWalletService', () => {
       expect.objectContaining({ did: 'did:key:z1' }),
     )
   })
+
+  test('skips registration when no DID exists for the requested network', async () => {
+    // no DID is found for any method, so the hedera lookup yields nothing and
+    // the registration is skipped rather than landing on the wrong issuer
+    vi.mocked(didService.find).mockResolvedValue([])
+    vi.mocked(didService.getMethods).mockReturnValue({ methods: ['key'] })
+    vi.mocked(didService.create).mockResolvedValue({ id: 'did:key:z1' } as any)
+    vi.mocked(issuerService.createIssuer).mockResolvedValue({} as any)
+    vi.mocked(verifierService.createVerifier).mockResolvedValue({} as any)
+    vi.mocked(schemaV2Service.create).mockResolvedValue({ id: 'schema-1' } as any)
+
+    await prepareWalletService.prepareWallet(authInfo, tenantAgent, {
+      schemas: [
+        {
+          name: 'TestSchema',
+          fields: [{ name: 'field1' }],
+          registrations: [{ protocol: 'Oid4vc', credentialFormat: 'SdJwtVc', network: 'hedera' }],
+        } as any,
+      ],
+    })
+
+    expect(schemaV2Service.registration).not.toHaveBeenCalled()
+  })
+
+  test('continues with remaining registrations when a DID lookup fails', async () => {
+    // the wallet is already prepared (main 'key' DID resolves); the 'hedera'
+    // lookup throws, which must not abort the still-valid 'key' registration
+    vi.mocked(didService.find).mockImplementation((_agent, req: any) => {
+      if (req.method === 'hedera') return Promise.reject(new Error('wallet lookup failure'))
+      return Promise.resolve([{ id: 'did:key:z1' }] as any)
+    })
+    vi.mocked(schemaV2Service.create).mockResolvedValue({ id: 'schema-1' } as any)
+    vi.mocked(schemaV2Service.registration).mockResolvedValue({})
+
+    await prepareWalletService.prepareWallet(authInfo, tenantAgent, {
+      schemas: [
+        {
+          name: 'TestSchema',
+          fields: [{ name: 'field1' }],
+          registrations: [
+            { protocol: 'Oid4vc', credentialFormat: 'SdJwtVc', network: 'hedera' },
+            { protocol: 'Oid4vc', credentialFormat: 'SdJwtVc', network: 'key' },
+          ],
+        } as any,
+      ],
+    })
+
+    // hedera skipped (lookup threw), key still registered
+    expect(schemaV2Service.registration).toHaveBeenCalledTimes(1)
+    expect(schemaV2Service.registration).toHaveBeenCalledWith(
+      authInfo,
+      tenantAgent,
+      'schema-1',
+      expect.objectContaining({ network: 'key', did: 'did:key:z1' }),
+    )
+  })
 })

--- a/heka-identity-service/src/prepare-wallet/__tests__/prepare-wallet.service.test.ts
+++ b/heka-identity-service/src/prepare-wallet/__tests__/prepare-wallet.service.test.ts
@@ -146,4 +146,65 @@ describe('PrepareWalletService', () => {
     expect(schemaV2Service.create).toHaveBeenCalledTimes(1)
     expect(schemaV2Service.registration).toHaveBeenCalledTimes(1)
   })
+
+  test('registers schema against the issuer DID matching the registration network', async () => {
+    // wallet check (method 'key') returns []; per-network lookup for 'hedera'
+    // resolves the hedera DID created during preparation
+    vi.mocked(didService.find).mockImplementation((_agent, req: any) =>
+      Promise.resolve(req.method === 'hedera' ? ([{ id: 'did:hedera:zH' }] as any) : []),
+    )
+    vi.mocked(didService.getMethods).mockReturnValue({ methods: ['key', 'hedera'] })
+    vi.mocked(didService.create)
+      .mockResolvedValueOnce({ id: 'did:key:z1' } as any)
+      .mockResolvedValueOnce({ id: 'did:hedera:zH' } as any)
+    vi.mocked(issuerService.createIssuer).mockResolvedValue({} as any)
+    vi.mocked(verifierService.createVerifier).mockResolvedValue({} as any)
+    vi.mocked(schemaV2Service.create).mockResolvedValue({ id: 'schema-1' } as any)
+    vi.mocked(schemaV2Service.registration).mockResolvedValue({})
+
+    await prepareWalletService.prepareWallet(authInfo, tenantAgent, {
+      schemas: [
+        {
+          name: 'TestSchema',
+          fields: [{ name: 'field1' }],
+          registrations: [{ protocol: 'Oid4vc', credentialFormat: 'SdJwtVc', network: 'hedera' }],
+        } as any,
+      ],
+    })
+
+    // the hedera registration must land on the hedera issuer DID, not the main did:key
+    expect(schemaV2Service.registration).toHaveBeenCalledWith(
+      authInfo,
+      tenantAgent,
+      'schema-1',
+      expect.objectContaining({ network: 'hedera', did: 'did:hedera:zH' }),
+    )
+  })
+
+  test('falls back to the main DID when a registration has no network', async () => {
+    vi.mocked(didService.find).mockResolvedValue([])
+    vi.mocked(didService.getMethods).mockReturnValue({ methods: ['key'] })
+    vi.mocked(didService.create).mockResolvedValue({ id: 'did:key:z1' } as any)
+    vi.mocked(issuerService.createIssuer).mockResolvedValue({} as any)
+    vi.mocked(verifierService.createVerifier).mockResolvedValue({} as any)
+    vi.mocked(schemaV2Service.create).mockResolvedValue({ id: 'schema-1' } as any)
+    vi.mocked(schemaV2Service.registration).mockResolvedValue({})
+
+    await prepareWalletService.prepareWallet(authInfo, tenantAgent, {
+      schemas: [
+        {
+          name: 'TestSchema',
+          fields: [{ name: 'field1' }],
+          registrations: [{ protocol: 'Oid4vc', credentialFormat: 'SdJwtVc' }],
+        } as any,
+      ],
+    })
+
+    expect(schemaV2Service.registration).toHaveBeenCalledWith(
+      authInfo,
+      tenantAgent,
+      'schema-1',
+      expect.objectContaining({ did: 'did:key:z1' }),
+    )
+  })
 })

--- a/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
+++ b/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
@@ -90,6 +90,16 @@ export class PrepareWalletService {
     if (req.schemas) {
       logger.info(`Create ${req.schemas.length} schemas`)
 
+      const didByNetwork = new Map<DidMethod, string>([[PrepareWalletService.mainDidMethod, mainDid]])
+
+      const resolveDidForNetwork = async (network: DidMethod): Promise<string | undefined> => {
+        const cached = didByNetwork.get(network)
+        if (cached) return cached
+        const [didDoc] = await this.didService.find(tenantAgent, { method: network, own: true })
+        if (didDoc) didByNetwork.set(network, didDoc.id)
+        return didDoc?.id
+      }
+
       for (const schema of req.schemas) {
         let schemaId: string
         try {
@@ -102,11 +112,17 @@ export class PrepareWalletService {
         if (schema.registrations) {
           logger.info(`Register ${schema.registrations.length} types for schema ${schema.name}`)
           for (const reg of schema.registrations) {
+            const network = reg.network ?? PrepareWalletService.mainDidMethod
+            const did = await resolveDidForNetwork(network)
+            if (!did) {
+              logger.error(`No ${network} DID available to register schema "${schema.name}", skipping`)
+              continue
+            }
             try {
               await this.schemaV2Service.registration(authInfo, tenantAgent, schemaId, {
                 ...reg,
                 credentialFormat: credentialFormatToCredentialRegistrationFormat(reg.credentialFormat),
-                did: mainDid,
+                did,
               })
             } catch (error) {
               logger.info(`Registration for schema "${schema.name}" already exists, skipping`)

--- a/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
+++ b/heka-identity-service/src/prepare-wallet/prepare-wallet.service.ts
@@ -95,9 +95,14 @@ export class PrepareWalletService {
       const resolveDidForNetwork = async (network: DidMethod): Promise<string | undefined> => {
         const cached = didByNetwork.get(network)
         if (cached) return cached
-        const [didDoc] = await this.didService.find(tenantAgent, { method: network, own: true })
-        if (didDoc) didByNetwork.set(network, didDoc.id)
-        return didDoc?.id
+        try {
+          const [didDoc] = await this.didService.find(tenantAgent, { method: network, own: true })
+          if (didDoc) didByNetwork.set(network, didDoc.id)
+          return didDoc?.id
+        } catch (error) {
+          logger.error(`Failed to resolve ${network} DID`)
+          return undefined
+        }
       }
 
       for (const schema of req.schemas) {


### PR DESCRIPTION
**Description**:
- Fixed an issue with pre-registration of network-specific schemas (`/prepare-wallet` endpoint)
- Updated `swagger-spec.yml`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
