### PR TITLE
fix(auth): validate refresh token ownership on logout

### DIFF
--- a/heka-auth-service/src/oauth/guards/user.guard.ts
+++ b/heka-auth-service/src/oauth/guards/user.guard.ts
@@ -19,6 +19,8 @@ export class UserAuthGuard extends AuthGuard('jwt') {
       const request = context.switchToHttp().getRequest()
 
       const token = extractTokenFromRequest(request)
+      request['accessToken'] = token
+
       const storedToken = await this.tokenRepository.get(token)
       if (!storedToken) throw new UnauthorizedException()
 

--- a/heka-auth-service/src/oauth/oauth.controller.ts
+++ b/heka-auth-service/src/oauth/oauth.controller.ts
@@ -36,10 +36,10 @@ export class OAuthController {
   @ApiBearerAuth()
   @HttpCode(HttpStatus.RESET_CONTENT)
   @Post('revoke')
-  public async logout(@Body() body: LogoutRequest): Promise<void> {
+  public async logout(@AccessToken() accessToken: string, @Body() body: LogoutRequest): Promise<void> {
     this.logger.verbose('logout >')
 
-    await this.authService.logout(body)
+    await this.authService.logout(accessToken, body)
 
     this.logger.verbose('logout <')
   }

--- a/heka-auth-service/src/oauth/oauth.service.ts
+++ b/heka-auth-service/src/oauth/oauth.service.ts
@@ -63,13 +63,8 @@ export class OAuthService {
       throw new UnauthorizedException('Refresh token is incorrect.')
     }
 
-    // get access token
-    const tokenPayload = classFromJson(storedRefreshToken.payload, AccessTokenPayload).accessToken
-
-    // check dependencies between tokens
-    if (accessToken != tokenPayload) {
-      throw new UnauthorizedException('Refresh token is incorrect.')
-    }
+    // ensure the caller owns this refresh token (the bound access token must match)
+    this.assertCallerOwnsRefreshToken(accessToken, storedRefreshToken.payload)
 
     // ensure user exists
     const user = await this.userRepository.findOne({ id: storedRefreshToken.subject })
@@ -95,28 +90,40 @@ export class OAuthService {
     return await this.generateTokens(user)
   }
 
-  public async logout(data: LogoutRequest): Promise<void> {
-    // resolve access token by refresh token
+  public async logout(accessToken: string, data: LogoutRequest): Promise<void> {
+    // An unknown or already-revoked refresh token is a silent no-op (HTTP 205),
+    // whereas a token that exists but belongs to another caller is an explicit 401.
     const storedRefreshToken = await this.tokenRepository.get(data.refresh)
     if (!storedRefreshToken || !storedRefreshToken.payload) {
       return
     }
+
+    // ensure the caller owns the refresh token being revoked (prevents cross-user session revocation)
+    const pairedAccessToken = this.assertCallerOwnsRefreshToken(accessToken, storedRefreshToken.payload)
 
     const user = await this.userRepository.findOne({ id: storedRefreshToken.subject })
     if (!user) {
       return
     }
 
-    const accessToken = classFromJson(storedRefreshToken.payload, AccessTokenPayload).accessToken
-
     // skip token invalidation for demo user
     if (user.isDemoUser(this.configService.jwtConfig)) {
       return
     }
 
-    // revoke old tokens
-    await this.tokenRepository.revoke(accessToken)
-    await this.tokenRepository.revoke(data.refresh)
+    const em = this.tokenRepository.getEntityManager()
+    await em.transactional(async () => {
+      await this.tokenRepository.revoke(pairedAccessToken)
+      await this.tokenRepository.revoke(data.refresh)
+    })
+  }
+
+  private assertCallerOwnsRefreshToken(accessToken: string, refreshTokenPayload: string): string {
+    const pairedAccessToken = classFromJson(refreshTokenPayload, AccessTokenPayload).accessToken
+    if (accessToken !== pairedAccessToken) {
+      throw new UnauthorizedException('Refresh token is incorrect.')
+    }
+    return pairedAccessToken
   }
 
   private getOrgId(role: UserRole) {

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -34,8 +34,9 @@ describe('E2E authorization', () => {
     if (orm) await orm.close(true)
   })
 
+  let userSeq = 0
   const newUser = () => ({
-    name: 'user' + Date.now().toString(),
+    name: 'user' + Date.now().toString() + '-' + userSeq++,
     password: 'Password1234!',
   })
 
@@ -122,5 +123,41 @@ describe('E2E authorization', () => {
     const response = await request(app).get('/api/v1/user/profile')
 
     expect(response.status).toBe(401)
+  })
+
+  test('logout rejects revoking a refresh token owned by another user', async () => {
+    const register = (u: LoginRequest) =>
+      request(app)
+        .post('/api/v1/user/register')
+        .send({ name: u.name, password: u.password, role: UserRole.Issuer } satisfies RegisterUserRequest)
+
+    const login = (u: LoginRequest) => request(app).post('/api/v1/oauth/token').send(u)
+
+    const alice = newUser()
+    const bob = newUser()
+
+    expect((await register(alice)).status).toBe(201)
+    expect((await register(bob)).status).toBe(201)
+
+    const aliceLogin = await login(alice)
+    const bobLogin = await login(bob)
+    expect(aliceLogin.status).toBe(200)
+    expect(bobLogin.status).toBe(200)
+
+    // Bob authenticates with his own (valid) access token but targets Alice's refresh token → rejected.
+    const crossRevoke = await request(app)
+      .post('/api/v1/oauth/revoke')
+      .auth(bobLogin.body.access, { type: 'bearer' })
+      .send({ refresh: aliceLogin.body.refresh } satisfies LogoutRequest)
+
+    expect(crossRevoke.status).toBe(401)
+
+    // Alice's session is untouched: she can still revoke it herself.
+    const selfRevoke = await request(app)
+      .post('/api/v1/oauth/revoke')
+      .auth(aliceLogin.body.access, { type: 'bearer' })
+      .send({ refresh: aliceLogin.body.refresh } satisfies LogoutRequest)
+
+    expect(selfRevoke.status).toBe(205)
   })
 })

--- a/heka-auth-service/test/authorization.e2e.test.ts
+++ b/heka-auth-service/test/authorization.e2e.test.ts
@@ -152,11 +152,22 @@ describe('E2E authorization', () => {
 
     expect(crossRevoke.status).toBe(401)
 
-    // Alice's session is untouched: she can still revoke it herself.
+    // Alice's session is provably untouched - it's still refreshes successfully.
+    // Delay so the rotated access JWT does not collide with the original within the same second.
+    await new Promise((res) => setTimeout(res, 1000))
+
+    const aliceRefresh = await request(app)
+      .post('/api/v1/oauth/refresh')
+      .auth(aliceLogin.body.access, { type: 'bearer' })
+      .send({ refresh: aliceLogin.body.refresh } satisfies RefreshRequest)
+
+    expect(aliceRefresh.status).toBe(200)
+
+    // Alice can still revoke her (now rotated) session herself.
     const selfRevoke = await request(app)
       .post('/api/v1/oauth/revoke')
-      .auth(aliceLogin.body.access, { type: 'bearer' })
-      .send({ refresh: aliceLogin.body.refresh } satisfies LogoutRequest)
+      .auth(aliceRefresh.body.access, { type: 'bearer' })
+      .send({ refresh: aliceRefresh.body.refresh } satisfies LogoutRequest)
 
     expect(selfRevoke.status).toBe(205)
   })

--- a/heka-auth-service/test/unit/oauth.service.spec.ts
+++ b/heka-auth-service/test/unit/oauth.service.spec.ts
@@ -40,12 +40,14 @@ function storedRefreshToken(accessToken: string, subject = 'user-1') {
 
 function createMocks() {
   const userRepository = { findOne: vi.fn() } satisfies Partial<UserRepository>
+  const transactionEm = { transactional: vi.fn((cb: () => Promise<unknown>) => cb()) }
   const tokenRepository = {
     put: vi.fn().mockResolvedValue({ id: 'token-id', token: 'stored-token' }),
     updateToken: vi.fn(),
     revoke: vi.fn(),
     get: vi.fn(),
     getById: vi.fn(),
+    getEntityManager: vi.fn().mockReturnValue(transactionEm),
   } satisfies Partial<TokenRepository>
   const jwtService = {
     signAsync: vi.fn().mockResolvedValue('signed-jwt'),
@@ -71,7 +73,7 @@ function createMocks() {
     tokenRepository as unknown as TokenRepository,
   )
 
-  return { service, userRepository, tokenRepository, jwtService }
+  return { service, userRepository, tokenRepository, jwtService, transactionEm }
 }
 
 describe('OAuthService', () => {
@@ -79,10 +81,11 @@ describe('OAuthService', () => {
   let userRepository: ReturnType<typeof createMocks>['userRepository']
   let tokenRepository: ReturnType<typeof createMocks>['tokenRepository']
   let jwtService: ReturnType<typeof createMocks>['jwtService']
+  let transactionEm: ReturnType<typeof createMocks>['transactionEm']
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;({ service, userRepository, tokenRepository, jwtService } = createMocks())
+    ;({ service, userRepository, tokenRepository, jwtService, transactionEm } = createMocks())
   })
 
   describe('login', () => {
@@ -301,21 +304,46 @@ describe('OAuthService', () => {
   })
 
   describe('logout', () => {
-    it('should revoke both the access and refresh tokens', async () => {
+    it('should revoke both the access and refresh tokens inside a transaction when the caller owns them', async () => {
       tokenRepository.get.mockResolvedValue(storedRefreshToken('stored-access'))
       userRepository.findOne.mockResolvedValue(createMockUser())
 
-      await service.logout({ refresh: 'refresh-token' })
+      await service.logout('stored-access', { refresh: 'refresh-token' })
 
+      expect(transactionEm.transactional).toHaveBeenCalledTimes(1)
       expect(tokenRepository.revoke).toHaveBeenCalledWith('stored-access')
       expect(tokenRepository.revoke).toHaveBeenCalledWith('refresh-token')
+    })
+
+    it('should abort the transaction and surface the error when revoking a token fails', async () => {
+      tokenRepository.get.mockResolvedValue(storedRefreshToken('stored-access'))
+      userRepository.findOne.mockResolvedValue(createMockUser())
+      const failure = new Error('db unavailable')
+      tokenRepository.revoke.mockRejectedValueOnce(failure)
+
+      await expect(service.logout('stored-access', { refresh: 'refresh-token' })).rejects.toThrow(failure)
+
+      // the first revoke rejected inside the transactional callback, so the second never ran
+      expect(tokenRepository.revoke).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reject revoking a refresh token the caller does not own', async () => {
+      tokenRepository.get.mockResolvedValue(storedRefreshToken('stored-access'))
+
+      await expect(service.logout('another-users-access', { refresh: 'refresh-token' })).rejects.toThrow(
+        UnauthorizedException,
+      )
+
+      // ownership is checked before any user lookup or revocation
+      expect(userRepository.findOne).not.toHaveBeenCalled()
+      expect(tokenRepository.revoke).not.toHaveBeenCalled()
     })
 
     it('should skip revocation for a demo user', async () => {
       tokenRepository.get.mockResolvedValue(storedRefreshToken('stored-access'))
       userRepository.findOne.mockResolvedValue(createMockUser({ isDemoUser: vi.fn().mockReturnValue(true) }))
 
-      await service.logout({ refresh: 'refresh-token' })
+      await service.logout('stored-access', { refresh: 'refresh-token' })
 
       expect(tokenRepository.revoke).not.toHaveBeenCalled()
     })
@@ -323,7 +351,7 @@ describe('OAuthService', () => {
     it('should be a no-op when the refresh token is unknown', async () => {
       tokenRepository.get.mockResolvedValue(null)
 
-      await expect(service.logout({ refresh: 'unknown' })).resolves.toBeUndefined()
+      await expect(service.logout('any-access', { refresh: 'unknown' })).resolves.toBeUndefined()
 
       expect(userRepository.findOne).not.toHaveBeenCalled()
       expect(tokenRepository.revoke).not.toHaveBeenCalled()

--- a/heka-auth-service/test/unit/user.guard.spec.ts
+++ b/heka-auth-service/test/unit/user.guard.spec.ts
@@ -1,0 +1,75 @@
+import { type ExecutionContext, UnauthorizedException } from '@nestjs/common'
+
+import type { TokenRepository, UserRepository } from '../../src/core/database/repositories'
+import { UserAuthGuard } from '../../src/oauth/guards/user.guard'
+
+function createContext(headers: Record<string, string | undefined>): {
+  context: ExecutionContext
+  request: Record<string, unknown>
+} {
+  const request: Record<string, unknown> = { headers }
+  const context = {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext
+
+  return { context, request }
+}
+
+function createGuard() {
+  const userRepository = { findOneOrFail: vi.fn() } satisfies Partial<UserRepository>
+  const tokenRepository = { get: vi.fn() } satisfies Partial<TokenRepository>
+
+  const guard = new UserAuthGuard(
+    userRepository as unknown as UserRepository,
+    tokenRepository as unknown as TokenRepository,
+  )
+
+  return { guard, userRepository, tokenRepository }
+}
+
+describe('UserAuthGuard', () => {
+  it('should expose the access token and sender on the request, then allow the call', async () => {
+    const { guard, userRepository, tokenRepository } = createGuard()
+    const user = { id: 'user-1' }
+    tokenRepository.get.mockResolvedValue({ subject: 'user-1', token: 'access-token' })
+    userRepository.findOneOrFail.mockResolvedValue(user)
+
+    const { context, request } = createContext({ authorization: 'Bearer access-token' })
+
+    await expect(guard.canActivate(context)).resolves.toBe(true)
+
+    // the fix under test: the caller's access token is exposed for @AccessToken() on the revoke route
+    expect(request.accessToken).toBe('access-token')
+    expect(request.sender).toBe(user)
+    expect(tokenRepository.get).toHaveBeenCalledWith('access-token')
+    expect(userRepository.findOneOrFail).toHaveBeenCalledWith({ id: 'user-1' })
+  })
+
+  it('should throw UnauthorizedException when the Authorization header is missing', async () => {
+    const { guard, tokenRepository } = createGuard()
+    const { context } = createContext({})
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException)
+    expect(tokenRepository.get).not.toHaveBeenCalled()
+  })
+
+  it('should throw UnauthorizedException when the access token is not stored', async () => {
+    const { guard, userRepository, tokenRepository } = createGuard()
+    tokenRepository.get.mockResolvedValue(null)
+
+    const { context } = createContext({ authorization: 'Bearer unknown-token' })
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException)
+    expect(userRepository.findOneOrFail).not.toHaveBeenCalled()
+  })
+
+  it('should throw UnauthorizedException when the token subject has no user', async () => {
+    const { guard, userRepository, tokenRepository } = createGuard()
+    tokenRepository.get.mockResolvedValue({ subject: 'ghost', token: 'access-token' })
+    userRepository.findOneOrFail.mockRejectedValue(new Error('not found'))
+
+    const { context } = createContext({ authorization: 'Bearer access-token' })
+
+    await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException)
+  })
+})


### PR DESCRIPTION
**Description**:
- Fixed IDOR issue on the logout/revoke endpoint
- Added transactional revocation for both access and refresh tokens on logout

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
