### PR TITLE
fix(identity-service): use a proper comparator for schema field ordering

### DIFF
--- a/heka-identity-service/src/schema-v2/__tests__/schema-v2.service.test.ts
+++ b/heka-identity-service/src/schema-v2/__tests__/schema-v2.service.test.ts
@@ -149,6 +149,34 @@ describe('SchemaV2Service', () => {
       await expect(schemaV2Service.getById(authInfo, 'missing')).rejects.toThrow(NotFoundException)
       expect(em.findOne).toHaveBeenCalledWith(Schema, { owner: mockUser, id: 'missing' }, expect.anything())
     })
+
+    test('returns fields sorted by orderIndex when stored out of order', async () => {
+      const mockSchema = {
+        id: 'schema-1',
+        name: 'My Schema',
+        logo: null,
+        bgColor: '#eee',
+        isHidden: false,
+        orderIndex: 0,
+        owner: mockUser,
+        fields: {
+          toArray: () => [
+            { id: 'f2', name: 'second', orderIndex: 2 },
+            { id: 'f0', name: 'zeroth', orderIndex: 0 },
+            { id: 'f1', name: 'first', orderIndex: 1 },
+          ],
+        },
+        registrations: {
+          map: vi.fn().mockReturnValue([]),
+          count: () => 0,
+        },
+      }
+      vi.mocked(em.findOne).mockResolvedValue(mockSchema)
+
+      const result = await schemaV2Service.getById(authInfo, 'schema-1')
+
+      expect(result.fields.map((f) => f.name)).toEqual(['zeroth', 'first', 'second'])
+    })
   })
 
   describe('create', () => {
@@ -205,6 +233,44 @@ describe('SchemaV2Service', () => {
           did: 'did:key:z1',
         } as any),
       ).rejects.toThrow(BadRequestException)
+    })
+
+    test('registers AnonCreds attrNames sorted by orderIndex when stored out of order', async () => {
+      const mockSchema = {
+        id: 'schema-1',
+        name: 'Test',
+        owner: mockUser,
+        registrations: { map: vi.fn().mockReturnValue([]), count: () => 0 },
+        fields: {
+          toArray: () => [
+            { id: 'f2', name: 'second', orderIndex: 2 },
+            { id: 'f0', name: 'zeroth', orderIndex: 0 },
+            { id: 'f1', name: 'first', orderIndex: 1 },
+          ],
+        },
+      }
+      // Schema lookups resolve to our schema; the existing-registration check resolves to null.
+      vi.mocked(em.findOne).mockImplementation((entity: any) =>
+        Promise.resolve(entity === Schema ? (mockSchema as any) : null),
+      )
+      vi.mocked(anoncredsRegistryService.registerSchema).mockResolvedValue({ schemaId: 'schema-id' } as any)
+      vi.mocked(anoncredsRegistryService.registerCredentialDefinition).mockResolvedValue({
+        credentialDefinitionId: 'cred-def-id',
+      } as any)
+      vi.mocked(revocationRegistryService.create).mockResolvedValue({
+        revocationRegistryDefinitionId: 'rev-reg-id',
+      } as any)
+
+      await schemaV2Service.registration(authInfo, tenantAgent, 'schema-1', {
+        protocol: ProtocolType.Aries,
+        credentialFormat: AriesCredentialRegistrationFormat.Anoncreds,
+        did: 'did:key:z1',
+      } as any)
+
+      expect(anoncredsRegistryService.registerSchema).toHaveBeenCalledWith(
+        tenantAgent,
+        expect.objectContaining({ attrNames: ['zeroth', 'first', 'second'] }),
+      )
     })
   })
 

--- a/heka-identity-service/src/schema-v2/schema-v2.service.ts
+++ b/heka-identity-service/src/schema-v2/schema-v2.service.ts
@@ -40,6 +40,9 @@ import { RegisterSchemaRequest, RegisterSchemaResponse } from './dto/register-sc
 
 type OpenId4VciCredentialConfigurationSupportedWithId = OpenId4VciCredentialConfigurationSupported & { id: string }
 
+const compareByOrderIndex = (a: { orderIndex?: number }, b: { orderIndex?: number }): number =>
+  (a.orderIndex ?? 0) - (b.orderIndex ?? 0)
+
 @Injectable()
 export class SchemaV2Service {
   private LOGO_STORAGE_ROOT_PATH = 'logo'
@@ -147,7 +150,7 @@ export class SchemaV2Service {
         version: '1.0.0',
         attrNames: schema.fields
           .toArray()
-          .sort((x) => x.orderIndex ?? 0)
+          .sort(compareByOrderIndex)
           .map((x) => x.name),
       })
 
@@ -196,7 +199,7 @@ export class SchemaV2Service {
       {},
       ...schema.fields
         .toArray()
-        .sort((s) => s.orderIndex ?? 0)
+        .sort(compareByOrderIndex)
         .map((x) => ({ [x.name]: {} })),
     )
 
@@ -276,7 +279,7 @@ export class SchemaV2Service {
     cryptographic_binding_methods_supported: ['cose_key'],
     claims: schema.fields
       .toArray()
-      .sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0))
+      .sort(compareByOrderIndex)
       .map((field) => ({ path: [schema.name, field.name] as [string, string] })),
     display: this.makeCredentialDisplay(schema),
   })
@@ -447,7 +450,7 @@ export class SchemaV2Service {
         registrationsCount: item.registrations.count(),
         fields: item.fields
           .toArray()
-          .sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0))
+          .sort(compareByOrderIndex)
           .map((f) => ({
             id: f.id,
             name: f.name,
@@ -488,7 +491,7 @@ export class SchemaV2Service {
       orderIndex: schema.orderIndex,
       fields: schema.fields
         .toArray()
-        .sort((s) => s.orderIndex ?? 0)
+        .sort(compareByOrderIndex)
         .map((f) => ({
           id: f.id,
           name: f.name,


### PR DESCRIPTION
**Description**:
- Fixed schema field ordering to properly compare entries by `orderIndex`

Fixes #130 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
