### PR TITLE
Fix/web UI eslint warnings

### DIFF
--- a/heka-identity-service-web-ui/scripts/prepare-demo-user.ts
+++ b/heka-identity-service-web-ui/scripts/prepare-demo-user.ts
@@ -100,7 +100,11 @@ async function main() {
     ],
   };
 
-  params.append('userLogo', new Blob([fs.readFileSync(imagePath)]), 'user.png');
+  params.append(
+    'userLogo',
+    new Blob([new Uint8Array(fs.readFileSync(imagePath))]),
+    'user.png',
+  );
   params.append('schemaLogo', schemaLogoBlob, 'schema.jpg');
   params.append('schemas', JSON.stringify([schema, mdlSchema]));
 

--- a/heka-identity-service-web-ui/src/components/Steps/FillCredentialData/FillCredentialData.tsx
+++ b/heka-identity-service-web-ui/src/components/Steps/FillCredentialData/FillCredentialData.tsx
@@ -75,7 +75,7 @@ export const FillCredentialData = ({
       );
       navigate(ROUTES.ISSUE_CREDENTIAL_TEMPLATES);
     },
-    [navigate, dispatch, context],
+    [navigate, dispatch, context, getValues],
   );
 
   const onUpdateTemplate = useCallback(async () => {

--- a/heka-identity-service-web-ui/src/components/Steps/SelectNetwork/SelectNetwork.tsx
+++ b/heka-identity-service-web-ui/src/components/Steps/SelectNetwork/SelectNetwork.tsx
@@ -78,13 +78,13 @@ export const SelectNetwork = ({
     if (onChangeNetwork && networkOptions.length > 0) {
       onChangeNetwork(networkOptions[0].value);
     }
-  }, [network, networkOptions, protocolType]);
+  }, [network, networkOptions, protocolType, onChangeNetwork]);
 
   useEffect(() => {
     if (onChangeDid && didOptions.length > 0) {
       onChangeDid(didOptions[0].value);
     }
-  }, [didOptions, network]);
+  }, [didOptions, network, onChangeDid]);
 
   const onNetworkChange = useCallback(
     (option: string) => {

--- a/heka-identity-service-web-ui/src/entities/User/model/services/changePassword.ts
+++ b/heka-identity-service-web-ui/src/entities/User/model/services/changePassword.ts
@@ -1,3 +1,4 @@
+/// <reference lib="es2022.error" />
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { ThunkConfig } from '@/app/providers/StoreProvider';
@@ -24,7 +25,7 @@ const requestChangePassword = async (
     });
   } catch (error) {
     if (error.response && error.response.status === 401) {
-      throw new Error('Current password is incorrect.');
+      throw new Error('Current password is incorrect.', { cause: error });
     } else {
       throw error;
     }

--- a/heka-identity-service-web-ui/src/pages/AgeVerificationDemo/AgeVerificationDemo.tsx
+++ b/heka-identity-service-web-ui/src/pages/AgeVerificationDemo/AgeVerificationDemo.tsx
@@ -177,7 +177,7 @@ const AgeVerificationFields = ({
 };
 
 const AgeVerificationDemo = () => {
-  const { t } = useTranslation();
+  useTranslation();
   const dispatch = useAppDispatch();
   const schemas = useSelector(getSchemas);
   const isPresentationCompleted = useSelector(getIsPresentationCompleted);

--- a/heka-identity-service-web-ui/src/pages/AgeVerificationDemo/AgeVerificationDemo.tsx
+++ b/heka-identity-service-web-ui/src/pages/AgeVerificationDemo/AgeVerificationDemo.tsx
@@ -177,7 +177,6 @@ const AgeVerificationFields = ({
 };
 
 const AgeVerificationDemo = () => {
-  useTranslation();
   const dispatch = useAppDispatch();
   const schemas = useSelector(getSchemas);
   const isPresentationCompleted = useSelector(getIsPresentationCompleted);

--- a/heka-identity-service-web-ui/src/pages/IssueCredential/AdvancedIssue/AdvancedIssue.tsx
+++ b/heka-identity-service-web-ui/src/pages/IssueCredential/AdvancedIssue/AdvancedIssue.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -100,6 +100,16 @@ export const AdvancedIssue = ({ type = 'issue' }: AdvancedIssueProps) => {
     }
   }, [issuanceTemplate, onChangeContextProperty]);
 
+  const onChangeDid = useMemo(
+    () => onChangeContextProperty('did'),
+    [onChangeContextProperty],
+  );
+
+  const onChangeNetwork = useMemo(
+    () => onChangeContextProperty('network'),
+    [onChangeContextProperty],
+  );
+
   const onSelectSchema = useCallback(() => {
     const nextStep = getRegistration(flowContext.schema!, {
       ...flowContext!,
@@ -129,7 +139,7 @@ export const AdvancedIssue = ({ type = 'issue' }: AdvancedIssueProps) => {
 
   useEffect(() => {
     onChangeContextProperty('schema')(singleSchema);
-  }, [singleSchema]);
+  }, [singleSchema, onChangeContextProperty]);
 
   return (
     <PreparationStepLayout
@@ -154,8 +164,8 @@ export const AdvancedIssue = ({ type = 'issue' }: AdvancedIssueProps) => {
           protocolType={flowContext.protocolType}
           did={flowContext.did}
           network={flowContext.network}
-          onChangeDid={onChangeContextProperty('did')}
-          onChangeNetwork={onChangeContextProperty('network')}
+          onChangeDid={onChangeDid}
+          onChangeNetwork={onChangeNetwork}
           onPrev={() => onChangeStep(IssueCredentialSteps.SelectProtocolType)}
           onNext={() => onChangeStep(IssueCredentialSteps.SelectSchema)}
         />

--- a/heka-identity-service-web-ui/src/pages/IssueCredential/Schemas/Schemas.tsx
+++ b/heka-identity-service-web-ui/src/pages/IssueCredential/Schemas/Schemas.tsx
@@ -27,13 +27,13 @@ import { EditorView } from './EditorView/EditorView';
 import * as cls from './Schemas.module.scss';
 
 export const Schemas = () => {
-  const { schemas = [], isLoading } = useSelector(
+  const { schemas, isLoading } = useSelector(
     (state: RootState) => state.schemas,
   );
   const { t } = useTranslation();
   const dispatch: AppDispatch = useDispatch();
 
-  const [localSchemas, setLocalSchemas] = useState(schemas);
+  const [localSchemas, setLocalSchemas] = useState(schemas ?? []);
   const [schema, setSchema] = useState<null | SchemaType>(null);
   const [isEditorModalOpen, setIsEditorModalOpen] = useState(false);
   const [isRegistrationsModalOpen, setRegistrationsModalOpen] = useState(false);
@@ -65,8 +65,8 @@ export const Schemas = () => {
   }, [dispatch, showActiveSchemas]);
 
   useEffect(() => {
-    setLocalSchemas(schemas);
-  }, [setLocalSchemas, isLoading]);
+    setLocalSchemas(schemas ?? []);
+  }, [setLocalSchemas, isLoading, schemas]);
 
   useEffect(() => {
     if (schema?.id) {

--- a/heka-identity-service-web-ui/src/pages/SignIn/SignIn.tsx
+++ b/heka-identity-service-web-ui/src/pages/SignIn/SignIn.tsx
@@ -55,7 +55,7 @@ const SignInView: React.FC = () => {
         /* empty */
       }
     },
-    [dispatch],
+    [dispatch, resetApplicationState],
   );
 
   const handleCreateAccount = useCallback(() => {

--- a/heka-identity-service-web-ui/src/pages/VerifyCredential/AdvancedVerification/AdvancedVerification.tsx
+++ b/heka-identity-service-web-ui/src/pages/VerifyCredential/AdvancedVerification/AdvancedVerification.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -96,11 +96,16 @@ const AdvancedVerification = ({
     }
   }, [verificationTemplate, onChangeContextProperty]);
 
+  const onChangeNetwork = useMemo(
+    () => onChangeContextProperty('network'),
+    [onChangeContextProperty],
+  );
+
   const onSelectProtocol = useCallback(() => {
     if (flowContext?.protocolType === ProtocolType.Oid4vc) {
-      flowContext.network = undefined;
+      onChangeContextProperty('network')(undefined);
     }
-    flowContext.did = undefined;
+    onChangeContextProperty('did')(undefined);
 
     const nextStep =
       flowContext?.protocolType === ProtocolType.Oid4vc
@@ -108,7 +113,7 @@ const AdvancedVerification = ({
         : VerifyCredentialSteps.SelectNetwork;
 
     onChangeStep(nextStep);
-  }, [flowContext?.protocolType, onChangeStep]);
+  }, [flowContext?.protocolType, onChangeStep, onChangeContextProperty]);
 
   const onRequest = useCallback(
     (attributes: Array<string>) => {
@@ -126,7 +131,7 @@ const AdvancedVerification = ({
 
   useEffect(() => {
     onChangeContextProperty('schema')(singleSchema);
-  }, [singleSchema]);
+  }, [singleSchema, onChangeContextProperty]);
 
   return (
     <PreparationStepLayout
@@ -151,7 +156,7 @@ const AdvancedVerification = ({
           protocolType={flowContext.protocolType}
           did={flowContext.did}
           network={flowContext.network}
-          onChangeNetwork={onChangeContextProperty('network')}
+          onChangeNetwork={onChangeNetwork}
           onPrev={() => onChangeStep(VerifyCredentialSteps.SelectProtocolType)}
           onNext={() => onChangeStep(VerifyCredentialSteps.SelectSchema)}
           didOptional={flowContext.protocolType === ProtocolType.Aries}

--- a/heka-identity-service-web-ui/src/shared/api/config/api.ts
+++ b/heka-identity-service-web-ui/src/shared/api/config/api.ts
@@ -109,7 +109,7 @@ const handleApiError = async (api: AxiosInstance, error: unknown) => {
     });
 
     return Promise.reject(error);
-  } catch (refreshError) {
+  } catch {
     // Token refresh failed - don't log error details as they may contain sensitive data
     console.error('[API] Token refresh failed for request:', {
       url: originalConfig.url,

--- a/heka-identity-service-web-ui/src/shared/ui/FormSelect/FormSelect.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/FormSelect/FormSelect.tsx
@@ -44,3 +44,5 @@ export const FormSelect = React.forwardRef(
     );
   },
 );
+
+FormSelect.displayName = 'FormSelect';

--- a/heka-identity-service-web-ui/src/shared/ui/Select/Select.tsx
+++ b/heka-identity-service-web-ui/src/shared/ui/Select/Select.tsx
@@ -37,7 +37,7 @@ export interface SelectProps extends AriaSelectPropsType {
 const DEFAULT_PLACEHOLDER = 'Select value';
 
 // todo: Research why the forwardRef is required. Fix it.
-export const Select = React.forwardRef((props: SelectProps, ref) => {
+export const Select = React.forwardRef((props: SelectProps, _ref) => {
   const {
     className,
     placeholder,
@@ -146,3 +146,5 @@ export const Select = React.forwardRef((props: SelectProps, ref) => {
     </AriaSelect>
   );
 });
+
+Select.displayName = 'Select';


### PR DESCRIPTION
### Description
Resolves the ESLint warnings reported in `heka-identity-service-web-ui`.

Lint categories fixed:
- `react-hooks/exhaustive-deps` (missing hook dependencies; potential stale-closure bugs)
- `@typescript-eslint/no-unused-vars`
- `react/display-name`
- `preserve-caught-error`

Affected files:
- `src/components/Steps/FillCredentialData/FillCredentialData.tsx`
- `src/components/Steps/SelectNetwork/SelectNetwork.tsx`
- `src/entities/User/model/services/changePassword.ts`
- `src/pages/AgeVerificationDemo/AgeVerificationDemo.tsx`
- `src/pages/IssueCredential/AdvancedIssue/AdvancedIssue.tsx`
- `src/pages/IssueCredential/Schemas/Schemas.tsx`
- `src/pages/SignIn/SignIn.tsx`
- `src/pages/VerifyCredential/AdvancedVerification/AdvancedVerification.tsx`
- `src/shared/api/config/api.ts`
- `src/shared/ui/FormSelect/FormSelect.tsx`
- `src/shared/ui/Select/Select.tsx`

Also included, not lint-driven:
- `scripts/prepare-demo-user.ts` — fixes `TS2322: Type 'Buffer' is not assignable to type
  'BlobPart'` by wrapping the `readFileSync` result in `new Uint8Array(...)`. Byte-identical
  at runtime. The file sits outside `tsconfig.json`'s `include` and outside the `lint:ts`
  glob, so CI never surfaced it.

No refactoring, no new dependencies, no `tsconfig.json` change.

### Steps to reproduce
1. Open the repository locally.
2. Go to:
   - `heka-identity-service-web-ui`
3. Run:
   ```bash
   yarn lint:ts
   ```
4. Observe warnings printed by ESLint.

### Expected behavior
`yarn lint:ts` should complete without warnings for the touched files.

### Actual behavior
`yarn lint:ts` reported 14 warnings, including missing React Hook dependencies
and other code-quality violations.

### Notes on the hook fixes
Two dependency additions are unsafe on their own: in `SelectNetwork` and
`Schemas`, the missing dependency changed identity on every render, so simply
adding it causes an infinite render loop. Both were made referentially stable
first — handlers memoised in the parent, and the `schemas = []` default moved to
its use sites — so the effects fire under exactly the same conditions as before.

One intentional behavior change: `AdvancedVerification.onSelectProtocol`
previously mutated `flowContext` in place through a stale closure, so the
`did`/`network` reset silently did nothing when the credential format was the
last thing changed. It now goes through `onChangeContextProperty` and always
applies.

### Note on `/// <reference lib="es2022.error" />`
`changePassword.ts` needs this file-local directive for `new Error(msg, { cause })` to
compile: `tsconfig.json` sets `"target": "es5"` with no `lib` override, so without it `tsc`
fails with `TS2554: Expected 0-1 arguments, but got 2`. It is not a `tsconfig.json` change.

### Review notes
Two CodeRabbit suggestions are intentionally not applied:

- **Add an `Error.cause` fallback for pre-ES2022 engines.** The compatibility premise is
  correct, but nothing in the repo reads `.cause` (`grep -rn "\.cause" src` returns no hits;
  `handleError` only reads `error.response`), so a fallback would set a property with no
  reader.
- **Forward the ref in `Select.tsx`.** Real, but pre-existing on `main`, where the parameter
  is equally never passed to `AriaSelect`; this PR only renamed `ref` → `_ref` to satisfy
  `no-unused-vars`. Forwarding it, or dropping `forwardRef`, would change runtime behavior
  and the public API. No call site passes a ref to `<Select>` or `<FormSelect>`. Better as a
  follow-up, together with the standing `// todo: Research why the forwardRef is required.`

### Acceptance criteria
- [x] Resolve the reported warnings in the listed files.
- [x] Ensure no behavior regression from dependency-array updates.
- [x] Re-run and confirm `yarn lint:ts` shows no warnings.

Verified: `yarn lint:ts` 0 problems · `tsc --noEmit` pass ·
`yarn test:unit` 32/32 · `yarn build:prod` pass.
