### PR TITLE
fix: restrict GitHub Actions token permissions to least privilege

### DIFF
--- a/.github/workflows/heka-auth-service-verify.yml
+++ b/.github/workflows/heka-auth-service-verify.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     defaults:

--- a/.github/workflows/heka-identity-service-verify.yml
+++ b/.github/workflows/heka-identity-service-verify.yml
@@ -14,9 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   verify:
@@ -25,6 +23,11 @@ jobs:
         working-directory: ./heka-identity-service
     name: Build and check
     runs-on: ubuntu-latest
+    permissions:
+      # Required to check out the repository
+      contents: read
+      # Required by vitest-coverage-report-action to post the coverage comment
+      pull-requests: write
 
     services:
       postgres:

--- a/.github/workflows/heka-identity-service-web-ui-verify.yml
+++ b/.github/workflows/heka-identity-service-web-ui-verify.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     defaults:


### PR DESCRIPTION
**Description**

Restrict `GITHUB_TOKEN` permissions in the three verify workflows to least privilege, addressing the OpenSSF Scorecard **Token-Permissions** findings.

### Changes

* `heka-identity-service-verify.yml`

  * Change top-level permissions to `contents: read`
  * Keep `pull-requests: write` only on the `verify` job, required by `vitest-coverage-report-action`
  * Remove unnecessary `checks: write` and `contents: write`
* `heka-auth-service-verify.yml`

  * Add `permissions: contents: read`
* `heka-identity-service-web-ui-verify.yml`

  * Add `permissions: contents: read`

Workflow configuration only. No application code, CI steps, or dependencies were changed.

### Verification

All three modified workflows include their own workflow file in their `paths` filters, so they are triggered by this PR.

The main behavior to verify is that `vitest-coverage-report-action` can still post the coverage comment with only `pull-requests: write` and `contents: read`.

### Related

OpenSSF Scorecard: https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/heka-identity-platform