### PR TITLE
ci: add CodeQL static analysis for TypeScript services

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,29 @@
+# CodeQL configuration used by .github/workflows/codeql-analysis.yml
+name: 'Heka Identity Platform CodeQL config'
+
+# Analysis is scoped to the two network-exposed TypeScript backend services.
+# The remaining TypeScript workspaces (heka-identity-service-web-ui,
+# heka-wallet) can be added once the initial alert backlog for these two has
+# been triaged - adding a line here is all that is required.
+paths:
+  - heka-identity-service
+  - heka-auth-service
+
+paths-ignore:
+  # Dependencies, build output and coverage reports are not committed, but stay
+  # excluded so a leftover working-tree copy can never enter the database.
+  - '**/node_modules'
+  - '**/dist'
+  - '**/coverage'
+  # Vendored Yarn release bundle (~3 MB of minified third-party JavaScript per
+  # service, committed via `yarnPath` in .yarnrc.yml).
+  - '**/.yarn'
+  # Generated wasm-bindgen bindings for the Indy Besu VDR: vendored, not
+  # maintained in this repository, and not meaningfully analysable.
+  - 'heka-identity-service/indy-besu-vdr-pkg'
+
+# The default query suite is used deliberately: it is the highest-precision set,
+# which keeps the first run's alert backlog reviewable. Consider switching to
+# `security-extended` once that backlog has been worked through.
+# queries:
+#   - uses: security-extended

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ on:
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   # Only supersede pull request runs. Pushes to `main` and the scheduled scan
   # must finish, otherwise the code scanning results for `main` go stale.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+name: CodeQL static analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly full scan (Mondays, 03:27 UTC). Keeps results fresh when a file is
+    # not touched for a long time and re-applies newly published CodeQL queries.
+    - cron: '27 3 * * 1'
+  workflow_dispatch:
+
+# Unlike the per-component verify workflows, this one deliberately has no
+# `paths` filter, so that every pull request to `main` is analysed and the check
+# can safely be made a required status check. The set of analysed sources is
+# narrowed in .github/codeql/codeql-config.yml instead, which keeps a run cheap
+# regardless of which component a pull request touches.
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Only supersede pull request runs. Pushes to `main` and the scheduled scan
+  # must finish, otherwise the code scanning results for `main` go stale.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze TypeScript services
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to check out the repository
+      contents: read
+      # Required to upload results to the code scanning dashboard
+      security-events: write
+      # `actions: read` and `packages: read` are intentionally omitted: they are
+      # only needed for private repositories and for private CodeQL packs
+      # respectively. Both would have to be added if this repository ever
+      # becomes private.
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          languages: javascript-typescript
+          # JavaScript/TypeScript is analysed straight from source, so no
+          # dependency installation or build step is needed. This also means no
+          # third-party package lifecycle script executes in this job.
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          # Keeps these results distinct from any other SARIF uploaded for the
+          # same commit.
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Description

Add a CodeQL static analysis workflow for the TypeScript backend services, addressing the OpenSSF Scorecard **SAST** finding (currently 0 — no SAST tool runs on commits).

This PR only enables the analysis. Alerts reported by the first run are not addressed here.

### Changes

- `.github/workflows/codeql-analysis.yml` (new)
  - Runs CodeQL analysis for `javascript-typescript` on pull requests to `main`, pushes to `main`, a weekly schedule, and `workflow_dispatch`.
  - Uses `build-mode: none`, so no dependencies are installed and no build or package lifecycle scripts are executed.
  - Uses least-privilege permissions: `contents: read` and `security-events: write` for the analysis job.

- `.github/codeql/codeql-config.yml` (new)
  - Scopes analysis to `heka-identity-service` and `heka-auth-service`.
  - Excludes dependencies, build/coverage output, vendored Yarn bundles, and generated Indy Besu VDR bindings.

The workflow follows the existing security conventions: `harden-runner` with `egress-policy: audit`, SHA-pinned actions with version comments, and concurrency control.

No application code, existing CI steps, or dependencies were changed.

### Notes for reviewer

- **No `paths` filter on the triggers.** The workflow runs for every pull request to `main`. The CodeQL scope is limited through `codeql-config.yml` instead.
- **`cancel-in-progress` applies only to pull requests.** Pushes to `main` and scheduled scans are allowed to complete so that code scanning results are not left stale.

### Verification

Before merging, make sure **CodeQL default setup** is disabled in `Settings → Code security → Code scanning`, since this workflow uses the workflow-based CodeQL setup.

After merging:

- Actions → `CodeQL static analysis` → `Analyze TypeScript services` completes successfully.
- Security → Code scanning shows results from `CodeQL`.
- Subsequent pull requests get a `Code scanning results / CodeQL` check.

The OpenSSF Scorecard **SAST** score should improve after CodeQL results are available and further pull requests are analyzed.

### Related

OpenSSF Scorecard: https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/heka-identity-platform