### PR TITLE
ci: pin container base images by digest, validate Gradle wrapper, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/heka-auth-service"
+      - "/heka-identity-service"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,36 @@
+name: Validate Gradle Wrapper
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validate Gradle Wrapper
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/heka-auth-service/Dockerfile
+++ b/heka-auth-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22 AS builder
+FROM node:22@sha256:8a34c4ab3ea2c5cd194f07e317b2a8f09461d3c8b05c4e34c8ccd56d56024c4d AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -13,7 +13,7 @@ RUN yarn install --immutable
 COPY . .
 RUN yarn build
 
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
 
 RUN apt-get update && apt-get install curl -y
 

--- a/heka-identity-service/Dockerfile
+++ b/heka-identity-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye-slim
+FROM node:22-bullseye-slim@sha256:5736e7ef1f3f2109be7ef8aea0cbdf931804aee9a18c6760507b8ded078b25a9
 
 ARG EXPRESS_PORT
 


### PR DESCRIPTION
**Description**:

Supply-chain hardening for the OpenSSF Scorecard findings that are **not** already covered by the open #194 (Scorecard workflow), #197 (Token-Permissions) and #198 (CodeQL / SAST). This PR is independent of those three and does not touch any of the same files, so it can land in any order relative to them.

* Pin the `node` base images in `heka-auth-service/Dockerfile` and `heka-identity-service/Dockerfile` by digest
* Add a `Validate Gradle Wrapper` workflow so the committed `heka-wallet/app/android/gradle/wrapper/gradle-wrapper.jar` is checked against Gradle's published checksums
* Add `.github/dependabot.yml` for `github-actions` and the two `docker` directories so the pins keep getting refreshed

### Changes by Scorecard check

**Pinned-Dependencies** (local scorecard 8 → 10)

- `heka-auth-service/Dockerfile`: `node:22` → `node:22@sha256:8a34c4ab…`, `node:22-bookworm-slim` → `node:22-bookworm-slim@sha256:83f487e0…`
- `heka-identity-service/Dockerfile`: `node:22-bullseye-slim` → `node:22-bullseye-slim@sha256:5736e7ef…`
- The digests are the current multi-arch manifest-list digests resolved with `docker buildx imagetools inspect`, i.e. exactly what the floating tags resolve to today, so the produced images do not change.

**Binary-Artifacts** (8 now; 9 expected once the new workflow has one successful run on `main`)

- New `.github/workflows/gradle-wrapper-validation.yml` using `gradle/actions/wrapper-validation` (SHA-pinned), same layout as the existing workflows (harden-runner first, pinned `actions/checkout`, `contents: read` only).
- Scorecard only exempts a committed `gradle-wrapper.jar` when this specific action has a successful run on the default-branch head, so the workflow runs on every push to `main` and every PR without a `paths` filter, on purpose. The job takes a few seconds.
- The jar's SHA-256 already matches a published Gradle wrapper checksum, so the check passes on the current tree.

**Dependabot**

- `github-actions` weekly, grouped into a single PR.
- `docker` weekly for `/heka-auth-service` and `/heka-identity-service`, so the digest pins above do not go stale.

| Check | Before | After (local `scorecard --local`) |
| --- | --- | --- |
| Pinned-Dependencies | 8 | 10 |
| Binary-Artifacts | 8 | 8 locally; 9 expected after the first wrapper-validation run on `main` (the wasm below stays flagged) |
| Dangerous-Workflow | 10 | 10 |
| Token-Permissions | 0 | unchanged here, addressed by #197 |
| SAST | 0 | unchanged here, addressed by #198 |

### Intentionally not changed

- `heka-identity-service/indy-besu-vdr-pkg/indy_besu_vdr_wasm_bg.wasm`: vendored wasm-bindgen build of the Indy Besu VDR that the identity service consumes at runtime. Removing it would mean building it from source in CI, which is out of scope here.
- `services: postgres:15` in the verify workflows: Scorecard does not count service containers, and those files are being modified in #197.
- `RUN yarn install` (without `--immutable`) in `heka-identity-service/Dockerfile`: Scorecard does not flag yarn; out of scope.
- No `npm` Dependabot entries: the four Yarn projects each have their own lockfile and there is no root manifest. Happy to add per-directory entries in a follow-up if maintainers want them.
- Not addressable by a PR: Branch-Protection, Code-Review, CII-Best-Practices, Signed-Releases.

**Related issue(s)**:

Related to #193; complements #194, #197 and #198.

**Notes for reviewer**:

- `actionlint .github/workflows/gradle-wrapper-validation.yml` is clean.
- `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` was run before and after; numbers are in the table above.
- Digests verified with `docker buildx imagetools inspect node:22`, `node:22-bookworm-slim` and `node:22-bullseye-slim`.
- Both publish workflows build their Dockerfile on PRs that touch the service directory, so the pinned images are exercised by this PR's own checks.

**Checklist**

- [x] Documented (Code comments, README, etc.) - n/a, CI configuration only
- [x] Tested (unit, integration, etc.) - actionlint, local scorecard, and the workflows run on this PR
